### PR TITLE
[FIX] 다중 메뉴 position것만 들어가게 수정 완료!!

### DIFF
--- a/app/src/main/java/com/eatssu/android/adapter/MenuPickAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/adapter/MenuPickAdapter.kt
@@ -4,11 +4,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.CheckBox
 import androidx.recyclerview.widget.RecyclerView
+import com.eatssu.android.data.model.response.ChangeMenuInfoListDto
 import com.eatssu.android.databinding.ItemMenuPickBinding
 
 class MenuPickAdapter(
-    private val menuNameArray: ArrayList<String>?,
-    private val menuIdArray: LongArray?
+    private val menuList: ChangeMenuInfoListDto,
 ) : RecyclerView.Adapter<MenuPickAdapter.ViewHolder>() {
 
     private val checkedItems: ArrayList<Pair<String, Long>> = ArrayList()
@@ -19,7 +19,7 @@ class MenuPickAdapter(
         private val checkBox: CheckBox = binding.checkBox
 
         fun bind(position: Int) {
-            binding.tvMenuName.text = menuNameArray?.get(position)
+            binding.tvMenuName.text = menuList.menuInfoList[position].name
             checkBox.isChecked = checkedItems.contains(getItem(position))
             checkBox.setOnClickListener { onCheckBoxClick(position) }
         }
@@ -36,12 +36,12 @@ class MenuPickAdapter(
     }
 
     override fun getItemCount(): Int {
-        return menuNameArray?.size ?: 0
+        return menuList.menuInfoList?.size ?: 0
     }
 
     fun getItem(position: Int): Pair<String, Long> {
-        val menuName = menuNameArray?.get(position) ?: ""
-        val menuId = menuIdArray?.get(position) ?: 0L
+        val menuName = menuList.menuInfoList[position].name
+        val menuId = menuList.menuInfoList[position].menuId
         return Pair(menuName, menuId)
     }
 

--- a/app/src/main/java/com/eatssu/android/adapter/TodayMealAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/adapter/TodayMealAdapter.kt
@@ -55,11 +55,11 @@ class TodayMealAdapter(private val dataList: GetTodayMealResponseDto) :
             intent.putExtra(
                 "itemId", dataList[position].mealId
             )
+            intent.putExtra("mealId",dataList[position].mealId)
             intent.putExtra(
                 "menuType", MenuType.CHANGE.toString()
             )
 
-//            val changeMenuInfoList =dataList[position].changeMenuInfoList[position].menuId
             val menuIds = mutableListOf<Long>()
             val menuNames = mutableListOf<String>()
 
@@ -71,10 +71,7 @@ class TodayMealAdapter(private val dataList: GetTodayMealResponseDto) :
             }
 
             val menuIdArray = menuIds.toLongArray()
-            val menuNameArray = menuNames.toList()?.let { ArrayList(it) }
-
-//            val arrayList: ArrayList<Long>? = longArray?.toList()?.let { ArrayList(it) }
-
+            val menuNameArray = ArrayList(menuNames.toList())
 
             intent.putExtra("menuIdArray",menuIdArray)
             intent.putStringArrayListExtra("menuNameArray",menuNameArray)

--- a/app/src/main/java/com/eatssu/android/data/model/response/ChangeMenuInfo.kt
+++ b/app/src/main/java/com/eatssu/android/data/model/response/ChangeMenuInfo.kt
@@ -1,0 +1,6 @@
+package com.eatssu.android.data.model.response
+
+data class ChangeMenuInfo(
+    val menuId: Long,
+    val name: String,
+)

--- a/app/src/main/java/com/eatssu/android/data/model/response/ChangeMenuInfoListDto.kt
+++ b/app/src/main/java/com/eatssu/android/data/model/response/ChangeMenuInfoListDto.kt
@@ -1,0 +1,5 @@
+package com.eatssu.android.data.model.response
+
+data class ChangeMenuInfoListDto (
+    val menuInfoList: List<ChangeMenuInfo>
+)

--- a/app/src/main/java/com/eatssu/android/data/model/response/GetTodayMealResponseDto.kt
+++ b/app/src/main/java/com/eatssu/android/data/model/response/GetTodayMealResponseDto.kt
@@ -1,15 +1,10 @@
 package com.eatssu.android.data.model.response
 
-typealias GetTodayMealResponseDto = List<GetTodayMeal>;
+typealias GetTodayMealResponseDto = List<GetTodayMeal>
 
 data class GetTodayMeal(
     val mealId: Long,
     val price: Long,
     val mainGrade: Double,
-    val changeMenuInfoList: List<ChangeMenuInfoList>,
-)
-
-data class ChangeMenuInfoList(
-    val menuId: Long,
-    val name: String,
+    val changeMenuInfoList: List<ChangeMenuInfo>,
 )

--- a/app/src/main/java/com/eatssu/android/data/service/MenuService.kt
+++ b/app/src/main/java/com/eatssu/android/data/service/MenuService.kt
@@ -1,5 +1,6 @@
 package com.eatssu.android.data.service
 
+import com.eatssu.android.data.model.response.ChangeMenuInfoListDto
 import com.eatssu.android.data.model.response.GetFixedMenuResponseDto
 import com.eatssu.android.data.model.response.GetTodayMealResponseDto
 import retrofit2.Call
@@ -18,4 +19,9 @@ interface MenuService {
     fun getFixMenu(
         @Query("restaurant") restaurant: String
     ): Call<GetFixedMenuResponseDto>
+
+    @GET("menu/menus")
+    fun getMenuByMealId(
+        @Query("mealId") mealId: Long
+    ): Call<ChangeMenuInfoListDto>
 }

--- a/app/src/main/java/com/eatssu/android/repository/MenuRepository.kt
+++ b/app/src/main/java/com/eatssu/android/repository/MenuRepository.kt
@@ -2,13 +2,12 @@ package com.eatssu.android.repository
 
 import com.eatssu.android.data.enums.Restaurant
 import com.eatssu.android.data.enums.Time
+import com.eatssu.android.data.model.response.ChangeMenuInfoListDto
 import com.eatssu.android.data.model.response.GetFixedMenuResponseDto
 import com.eatssu.android.data.model.response.GetTodayMealResponseDto
 import com.eatssu.android.data.service.MenuService
 import retrofit2.Call
-import retrofit2.Retrofit
 
-// MenuRepository.kt
 
 class MenuRepository(private val menuService: MenuService) {
 
@@ -18,5 +17,9 @@ class MenuRepository(private val menuService: MenuService) {
 
     fun getFixedMenu(restaurant: Restaurant): Call<GetFixedMenuResponseDto> {
         return menuService.getFixMenu(restaurant.toString())
+    }
+
+    fun getMenuIdByMealId(mealId: Long): Call<ChangeMenuInfoListDto> {
+        return menuService.getMenuByMealId(mealId)
     }
 }

--- a/app/src/main/java/com/eatssu/android/view/review/MenuPickActivity.kt
+++ b/app/src/main/java/com/eatssu/android/view/review/MenuPickActivity.kt
@@ -6,12 +6,16 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.eatssu.android.adapter.MenuPickAdapter
 import com.eatssu.android.data.RetrofitImpl.retrofit
 import com.eatssu.android.data.service.MenuService
 import com.eatssu.android.data.service.ReviewService
 import com.eatssu.android.databinding.ActivityMenuPickBinding
+import com.eatssu.android.repository.MenuRepository
+import com.eatssu.android.viewmodel.MenuViewModel
+import com.eatssu.android.viewmodel.factory.MenuViewModelFactory
 
 
 class MenuPickActivity : AppCompatActivity() {
@@ -19,6 +23,8 @@ class MenuPickActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMenuPickBinding
     private lateinit var menuPickAdapter: MenuPickAdapter
 
+    private lateinit var viewModel: MenuViewModel
+    private lateinit var repository: MenuRepository
 
     private lateinit var menuService: MenuService
     private lateinit var reviewService: ReviewService
@@ -36,20 +42,25 @@ class MenuPickActivity : AppCompatActivity() {
 
         menuService = retrofit.create(MenuService::class.java)
         reviewService = retrofit.create(ReviewService::class.java)
+        repository = MenuRepository(menuService)
+
+        val mealId = intent.getLongExtra("mealId",-1)
+        viewModel = ViewModelProvider(this, MenuViewModelFactory(repository))[MenuViewModel::class.java]
+
+        Log.d("post", "!!!받은" + viewModel.findMenuItemByMealId(mealId).toString())
+        Log.d("post", "!!!받은2" + viewModel.menuBymealId.toString())
+
+        viewModel.menuBymealId.observe(this) { menuList ->
+            menuPickAdapter = MenuPickAdapter(menuList)
+            val recyclerView = binding.rvMenuPicker
+            recyclerView.adapter = menuPickAdapter
+            recyclerView.layoutManager = LinearLayoutManager(this)
+            recyclerView.setHasFixedSize(true)
+            //구분선 주석처리
+//            recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayout.VERTICAL))
+        }
 
 
-        val menuNameArray = intent.getStringArrayListExtra("menuNameArray")
-        val menuIdArray = intent.getLongArrayExtra("menuIdArray")
-
-        Log.d("post", "받은" + menuNameArray.toString())
-
-
-        /* 리사이클러뷰 어댑터 */
-        menuPickAdapter = MenuPickAdapter(menuNameArray, menuIdArray)
-        val recyclerView = binding.rvMenuPicker
-        recyclerView.adapter = menuPickAdapter
-        recyclerView.layoutManager = LinearLayoutManager(this)
-        recyclerView.setHasFixedSize(true)
 
         // "다음" 버튼 클릭 시, 다음 항목의 리뷰화면을 시작합니다.
         binding.btnNextReview.setOnClickListener {

--- a/app/src/main/java/com/eatssu/android/view/review/ReviewListActivity.kt
+++ b/app/src/main/java/com/eatssu/android/view/review/ReviewListActivity.kt
@@ -80,10 +80,13 @@ class ReviewListActivity : AppCompatActivity() {
             "CHANGE" -> {
                 viewModel.loadReviewList(MenuType.CHANGE, itemId, 0)
                 viewModel.loadReviewInfo(MenuType.CHANGE, itemId, 0)
+                val mealId = itemId
 
                 binding.btnNextReview.setOnClickListener() {
                     val intent = Intent(this, MenuPickActivity::class.java)  // 인텐트를 생성해줌,
                     intent.putExtra("itemId", itemId)
+                    intent.putExtra("mealId", mealId)
+
                     intent.putExtra("menuType", menuType)
 
                     intent.putStringArrayListExtra("menuNameArray", menuNameArray)
@@ -122,9 +125,6 @@ class ReviewListActivity : AppCompatActivity() {
 
         viewModel.reviewInfo.observe(this) { reviewInfo ->
             Log.d("post", reviewInfo.toString())
-
-            Log.d("post", reviewInfo.menuName.javaClass.name)
-//            itemName = reviewInfo.menuName as ArrayList<String>
 
             binding.tvMenu.text = reviewInfo.menuName.toString()
 

--- a/app/src/main/java/com/eatssu/android/viewmodel/MenuViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/viewmodel/MenuViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eatssu.android.data.enums.Restaurant
 import com.eatssu.android.data.enums.Time
+import com.eatssu.android.data.model.response.ChangeMenuInfoListDto
 import com.eatssu.android.data.model.response.GetFixedMenuResponseDto
 import com.eatssu.android.data.model.response.GetTodayMealResponseDto
 import com.eatssu.android.repository.MenuRepository
@@ -35,6 +36,10 @@ class MenuViewModel(private val repository: MenuRepository) : ViewModel() {
 
     private val _fixedMenuDataFood = MutableLiveData<GetFixedMenuResponseDto>()
     val fixedMenuDataFood: MutableLiveData<GetFixedMenuResponseDto> = _fixedMenuDataFood
+
+    private val _menuBymealId = MutableLiveData<ChangeMenuInfoListDto>()
+    val menuBymealId: MutableLiveData<ChangeMenuInfoListDto> = _menuBymealId
+
 
     fun loadTodayMeal(
         menuDate: String,
@@ -103,6 +108,31 @@ class MenuViewModel(private val repository: MenuRepository) : ViewModel() {
                     }
 
                     override fun onFailure(call: Call<GetFixedMenuResponseDto>, t: Throwable) {
+                        Log.d("post", "onFailure 에러: ${t.message}")
+                    }
+                })
+        }
+    }
+
+    fun findMenuItemByMealId(mealId: Long) {
+        viewModelScope.launch {
+            repository.getMenuIdByMealId(mealId)
+                .enqueue(object : Callback<ChangeMenuInfoListDto> {
+                    override fun onResponse(
+                        call: Call<ChangeMenuInfoListDto>,
+                        response: Response<ChangeMenuInfoListDto>
+                    ) {
+                        if (response.isSuccessful) {
+                            Log.d("post", "onResponse 성공" + response.body())
+
+                            menuBymealId.postValue(response.body())
+
+                        } else {
+                            Log.d("post", "onResponse 실패")
+                        }
+                    }
+
+                    override fun onFailure(call: Call<ChangeMenuInfoListDto>, t: Throwable) {
                         Log.d("post", "onFailure 에러: ${t.message}")
                     }
                 })


### PR DESCRIPTION
## 개요

> meadId로 세부 메뉴 조회하는 API를 사용해서 리팩토링함.

- 이전 방식: 홈화면에서 메뉴 리스트의 이름과 ID를 두 개의 리스트로 만들어서 넘겼는데
- 변경된 방식: API 호출해서 바로 바인딩 하는 방법으로 변경 