### PR TITLE
[Feat] update dialog & notice dialog [Firebase Remote Config]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,13 @@
         </activity>
 
 
+        <activity
+            android:name=".ui.common.AndroidMessageDialogActivity"
+            android:exported="true">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
 
         <activity
             android:name=".ui.common.ForceUpdateDialogActivity"
@@ -70,9 +77,6 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
-<!--        <meta-data-->
-<!--            android:name="com.kakao.sdk.AppKey"-->
-<!--            android:value="$KAKAO_NATIVE_APP_KEY" />-->
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"

--- a/app/src/main/java/com/eatssu/android/base/BaseActivity.kt
+++ b/app/src/main/java/com/eatssu/android/base/BaseActivity.kt
@@ -1,7 +1,9 @@
 package com.eatssu.android.base
 
+import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -11,8 +13,14 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.ViewModelProvider
 import androidx.viewbinding.ViewBinding
 import com.eatssu.android.R
+import com.eatssu.android.data.repository.FirebaseRemoteConfigRepository
+import com.eatssu.android.ui.common.AndroidMessageDialogActivity
+import com.eatssu.android.ui.common.ForceUpdateDialogActivity
+import com.eatssu.android.ui.common.VersionViewModel
+import com.eatssu.android.ui.common.VersionViewModelFactory
 import com.eatssu.android.util.NetworkConnection
 
 
@@ -27,6 +35,8 @@ abstract class BaseActivity<B : ViewBinding>(
     protected lateinit var toolbarTitle: TextView
     protected lateinit var backBtn: ImageButton
 
+    private lateinit var versionViewModel: VersionViewModel
+    private lateinit var firebaseRemoteConfigRepository: FirebaseRemoteConfigRepository
 
     private val networkCheck: NetworkConnection by lazy {
         NetworkConnection(this)
@@ -50,6 +60,17 @@ abstract class BaseActivity<B : ViewBinding>(
 
         networkCheck.register() // 네트워크 객체 등록
 
+
+        firebaseRemoteConfigRepository = FirebaseRemoteConfigRepository()
+        versionViewModel = ViewModelProvider(this, VersionViewModelFactory(firebaseRemoteConfigRepository))[VersionViewModel::class.java]
+
+        if(versionViewModel.checkForceUpdate()){
+            showForceUpdateDialog()
+        }
+
+        if(versionViewModel.checkAndroidMessage().dialog) {
+            showAndroidMessageDialog(versionViewModel.checkAndroidMessage().message)
+        }
 
         _binding = bindingFactory(layoutInflater, findViewById(R.id.fl_content), true)
     }
@@ -79,5 +100,18 @@ abstract class BaseActivity<B : ViewBinding>(
             }
         }
         return super.dispatchTouchEvent(ev)
+    }
+
+
+    private fun showForceUpdateDialog() {
+        val intent = Intent(this, ForceUpdateDialogActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun showAndroidMessageDialog(message: String) {
+        val intent = Intent(this, AndroidMessageDialogActivity::class.java)
+        intent.putExtra("message",message)
+        Log.d("message",message.toString())
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/eatssu/android/base/BaseActivity.kt
+++ b/app/src/main/java/com/eatssu/android/base/BaseActivity.kt
@@ -111,7 +111,7 @@ abstract class BaseActivity<B : ViewBinding>(
     private fun showAndroidMessageDialog(message: String) {
         val intent = Intent(this, AndroidMessageDialogActivity::class.java)
         intent.putExtra("message",message)
-        Log.d("message",message.toString())
+        Log.d("BaseActivity", "공지사항: $message")
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/entity/AndroidMessage.kt
+++ b/app/src/main/java/com/eatssu/android/data/entity/AndroidMessage.kt
@@ -1,0 +1,6 @@
+package com.eatssu.android.data.entity
+
+data class AndroidMessage(
+    val dialog: Boolean,
+    val message: String
+)

--- a/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
+++ b/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
@@ -1,11 +1,12 @@
 package com.eatssu.android.data.repository
 
 import android.util.Log
-import androidx.lifecycle.MutableLiveData
 import com.eatssu.android.R
+import com.eatssu.android.data.entity.AndroidMessage
 import com.eatssu.android.data.entity.FirebaseInfoItem
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import com.google.gson.Gson
 import org.json.JSONArray
 
 class FirebaseRemoteConfigRepository {
@@ -14,7 +15,7 @@ class FirebaseRemoteConfigRepository {
     fun init() {
         // Firebase Remote Config 초기화 설정
         val configSettings = FirebaseRemoteConfigSettings.Builder()
-            .setMinimumFetchIntervalInSeconds(3600) // 캐시된 값을 1시간마다 업데이트
+            .setMinimumFetchIntervalInSeconds(1) // 캐시된 값을 1시간마다 업데이트
             .build()
         instance.setConfigSettingsAsync(configSettings)
         instance.setDefaultsAsync(R.xml.firebase_remote_config)
@@ -29,6 +30,20 @@ class FirebaseRemoteConfigRepository {
                 throw RuntimeException("fetchAndActivate 실패")
             }
         }
+    }
+
+    fun getAndroidMessage(): AndroidMessage {
+
+        val jsonString =instance.getString("android_message")
+
+        // Gson을 사용하여 JSON 문자열을 DTO로 파싱
+        val serverStatus: AndroidMessage = Gson().fromJson(jsonString, AndroidMessage::class.java)
+
+        // 파싱된 결과 확인
+        println("Dialog: ${serverStatus.dialog}")
+        println("Message: ${serverStatus.message}")
+
+        return serverStatus
     }
 
     fun getForceUpdate(): Boolean {

--- a/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
+++ b/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
@@ -34,10 +34,8 @@ class FirebaseRemoteConfigRepository {
 
     fun getAndroidMessage(): AndroidMessage {
 
-        val jsonString =instance.getString("android_message")
-
         // Gson을 사용하여 JSON 문자열을 DTO로 파싱
-        val serverStatus: AndroidMessage = Gson().fromJson(jsonString, AndroidMessage::class.java)
+        val serverStatus: AndroidMessage = Gson().fromJson(instance.getString("android_message"), AndroidMessage::class.java)
 
         // 파싱된 결과 확인
         println("Dialog: ${serverStatus.dialog}")

--- a/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
+++ b/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
@@ -15,7 +15,7 @@ class FirebaseRemoteConfigRepository {
     fun init() {
         // Firebase Remote Config 초기화 설정
         val configSettings = FirebaseRemoteConfigSettings.Builder()
-            .setMinimumFetchIntervalInSeconds(1) // 캐시된 값을 1시간마다 업데이트
+            .setMinimumFetchIntervalInSeconds(3600) // 캐시된 값을 1시간마다 업데이트
             .build()
         instance.setConfigSettingsAsync(configSettings)
         instance.setDefaultsAsync(R.xml.firebase_remote_config)

--- a/app/src/main/java/com/eatssu/android/ui/common/AndroidMessageDialogActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/common/AndroidMessageDialogActivity.kt
@@ -1,0 +1,37 @@
+package com.eatssu.android.ui.common
+
+
+import android.app.AlertDialog
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+
+
+class AndroidMessageDialogActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        showDialog()
+    }
+
+    private fun showDialog() {
+        val builder = AlertDialog.Builder(this)
+
+        builder.setTitle("공지")
+        val message = intent.getStringExtra("message")
+        Log.d("message",message.toString())
+        builder.setMessage(intent.getStringExtra("message"))
+
+        builder.setPositiveButton("확인") { dialog, which ->
+            // Google Play Store의 앱 페이지로 이동하여 업데이트를 다운로드합니다.
+
+            // 다이얼로그를 종료합니다.
+            finish()
+        }
+
+        builder.setCancelable(false) // 사용자가 다이얼로그를 취소할 수 없도록 설정
+
+        val dialog = builder.create()
+        dialog.show()
+    }
+}

--- a/app/src/main/java/com/eatssu/android/ui/common/VersionViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/ui/common/VersionViewModel.kt
@@ -1,6 +1,8 @@
 package com.eatssu.android.ui.common
 
 import androidx.lifecycle.ViewModel
+import com.eatssu.android.BuildConfig.VERSION_NAME
+import com.eatssu.android.data.entity.AndroidMessage
 import com.eatssu.android.data.repository.FirebaseRemoteConfigRepository
 
 class VersionViewModel(private val repository: FirebaseRemoteConfigRepository) : ViewModel() {
@@ -11,10 +13,15 @@ class VersionViewModel(private val repository: FirebaseRemoteConfigRepository) :
     }
 
     fun checkForceUpdate(): Boolean {
-        return repository.getForceUpdate()
+        val lastVersion = checkAppVersion()
+        return VERSION_NAME != lastVersion && repository.getForceUpdate()
     }
 
-    fun getAppVersion(): String {
+    private fun checkAppVersion(): String {
         return repository.getAppVersion()
+    }
+
+    fun checkAndroidMessage(): AndroidMessage {
+        return repository.getAndroidMessage()
     }
 }

--- a/app/src/main/java/com/eatssu/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/main/MainActivity.kt
@@ -16,12 +16,8 @@ import com.eatssu.android.R
 import com.eatssu.android.base.BaseActivity
 import com.eatssu.android.data.entity.CalendarData
 import com.eatssu.android.data.model.response.GetMyInfoResponseDto
-import com.eatssu.android.data.repository.FirebaseRemoteConfigRepository
 import com.eatssu.android.data.service.MyPageService
 import com.eatssu.android.databinding.ActivityMainBinding
-import com.eatssu.android.ui.common.ForceUpdateDialogActivity
-import com.eatssu.android.ui.common.VersionViewModel
-import com.eatssu.android.ui.common.VersionViewModelFactory
 import com.eatssu.android.ui.main.calendar.CalendarAdapter
 import com.eatssu.android.ui.main.calendar.CalendarViewModel
 import com.eatssu.android.ui.main.calendar.OnItemClickListener
@@ -45,9 +41,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     lateinit var calendarAdapter: CalendarAdapter
     private var calendarList = ArrayList<CalendarData>()
 
-    private lateinit var versionViewModel: VersionViewModel
-    private lateinit var firebaseRemoteConfigRepository: FirebaseRemoteConfigRepository
-
     private lateinit var nickname: String
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -55,17 +48,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        firebaseRemoteConfigRepository = FirebaseRemoteConfigRepository()
-        versionViewModel = ViewModelProvider(this, VersionViewModelFactory(firebaseRemoteConfigRepository))[VersionViewModel::class.java]
-
-        if(versionViewModel.checkForceUpdate()){
-            showForceUpdateDialog()
-        }
-
         // 툴바 사용하지 않도록 설정
         toolbar.let {
-            toolbar.visibility= View.GONE
-            toolbarTitle.visibility= View.GONE
+            toolbar.visibility = View.GONE
+            toolbarTitle.visibility = View.GONE
             setSupportActionBar(it)
             supportActionBar?.setDisplayHomeAsUpEnabled(false)
             supportActionBar?.setDisplayShowTitleEnabled(false)
@@ -90,7 +76,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
                     //나중에 isNullOrBlank로 바꿀 것
                     if (nickname == "null") {
                         startActivity(intentNick)
-                        Log.d("MainActivity","닉네임이 null")
+                        Log.d("MainActivity", "닉네임이 null")
                     }
                 }
             }
@@ -119,7 +105,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
         val tabTitles = listOf("아침", "점심", "저녁")
 
         // 2. TabLayout과 ViewPager2를 연결하고, TabItem의 메뉴명을 설정한다.
-        TabLayoutMediator(tabLayout,
+        TabLayoutMediator(
+            tabLayout,
             viewPager
         ) { tab, position -> tab.text = tabTitles[position] }.attach()
 
@@ -222,7 +209,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
                 val tabTitles = listOf("아침", "점심", "저녁")
 
                 // 2. TabLayout과 ViewPager2를 연결하고, TabItem의 메뉴명을 설정한다.
-                TabLayoutMediator(tabLayout,
+                TabLayoutMediator(
+                    tabLayout,
                     viewPager
                 ) { tab, position -> tab.text = tabTitles[position] }.attach()
 
@@ -246,14 +234,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
                 startActivity(intent)  // 화면 전환을 시켜줌
                 true
             }
+
             else -> super.onOptionsItemSelected(item)
         }
     }
-
-
-    private fun showForceUpdateDialog() {
-        val intent = Intent(this, ForceUpdateDialogActivity::class.java)
-        startActivity(intent)
-    }
-
 }

--- a/app/src/main/res/xml/firebase_remote_config.xml
+++ b/app/src/main/res/xml/firebase_remote_config.xml
@@ -43,4 +43,9 @@
             ]
         </value>
     </entry>
+    <entry>
+        <key>android_message</key>
+        <value>{"dialog":true,"message":"지금은 서버 점검 중입니다. "}
+        </value>
+    </entry>
 </defaultsMap>


### PR DESCRIPTION
# 관련 이슈
- Resolves #106 

# 개요
1. Firebase Remote Config 버전 강제업데이트 로직 수정
  기존안 - 강제업데이트 여부가 true 면 -> 문제점: 최신 버전이어도 계속 다이알로그가 뜸
  수정안 - 현재 깔려 있는 버전과 다르고, 강제업데이트여부도 true여야 다이알로그 나오게

2. 공지사항용 다이알로그 추가
   true이면 아래 메시지가 뜸
```
{
  "dialog": false,
  "message": "지금은 서버 점검 중입니다. "
}
```


- 둘 다 baseActivity에서 작업함

# Check List
- [x] code formatter 적용 확인 (ctrl + alert + O ⇒ 안쓰는 import 제거 / ctrl + alert + L ⇒ 코드 정렬 등)
- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  main 브랜치의 최신 상태를 반영하고 있는지 확인