### PR TITLE
[Fix] 크리스마스 로고에서 기본 로고로 이미지 변경

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Cache Gradle packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -12,19 +12,19 @@
         android:layout_height="wrap_content"
         android:scaleType="centerInside"
         android:layout_margin="65dp"
-        android:src="@drawable/img_logo_snow"
+        android:src="@drawable/img_new_logo_white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/img_backgroud_snow"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+<!--    <ImageView-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:src="@drawable/img_backgroud_snow"-->
+<!--        app:layout_constraintBottom_toBottomOf="parent"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintTop_toTopOf="parent" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
크리스마스 이벤트 스플래쉬 이미지에서 기존 이미지로 변경


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img src="https://github.com/user-attachments/assets/42faee91-69b5-42f3-aaa9-94cbe3dffe07" width="150" />

## Issue

- Resolves #252 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

이슈 내용으로는 '앱 설치 로고 및 스플래시 기본으로 변경'으로 되어 있는데
스플래쉬는 바꿨는데 앱 설치 로고는 뭐를 말하는지 잘 모르겠습니다..! 
나머지는 원래부터 기존 이미지고 크리스마스 이미지는 더이상 사용되는 곳이 없더라구요
그리고 나중에 이벤트성 이미지로 또 바뀔수도 있어서 주석처리해뒀는데
필요없으면 지울게요~