### PR TITLE
[Modify] 스플래시에서 uiState와 uiEvent를 활용해서 분기처리하기

### DIFF
--- a/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
@@ -144,29 +144,29 @@ class TokenInterceptor @Inject constructor(
             }
         }
 
-        if (response.code == 404) {
-            runBlocking { logoutUseCase() }
-            Timber.e("404 + 다른 유저!")
-
-            Handler(Looper.getMainLooper()).post {
-                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
-                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                context.startActivity(intent)
-            }
-        }
-
-        if (response.code == 500) {
-            runBlocking { logoutUseCase() }
-            Timber.e("500 + 다른 유저")
-
-            Handler(Looper.getMainLooper()).post {
-                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
-                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                context.startActivity(intent)
-            }
-        }
+//        if (response.code == 404) {
+//            runBlocking { logoutUseCase() }
+//            Timber.e("404 + 다른 유저!")
+//
+//            Handler(Looper.getMainLooper()).post {
+//                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
+//                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
+//                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+//                context.startActivity(intent)
+//            }
+//        }
+//
+//        if (response.code == 500) {
+//            runBlocking { logoutUseCase() }
+//            Timber.e("500 + 다른 유저")
+//
+//            Handler(Looper.getMainLooper()).post {
+//                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
+//                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
+//                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+//                context.startActivity(intent)
+//            }
+//        }
 
         return response
     }

--- a/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
@@ -114,10 +114,6 @@ class TokenInterceptor @Inject constructor(
                     return chain.proceed(newRequest)
                 } else {
                     /**
-                     *
-                     *
-                     * refreshTokenResponse : Response{protocol=http/1.1, code=401, message=, url=https://prod.eat-ssu.shop/oauths/reissue/token}
-                     * 위 상황에서도 로그아웃
                      * 리프레쉬도 상한 상태
                      */
                     runBlocking { logoutUseCase() }
@@ -144,29 +140,29 @@ class TokenInterceptor @Inject constructor(
             }
         }
 
-//        if (response.code == 404) {
+        if (response.code == 404) {
 //            runBlocking { logoutUseCase() }
-//            Timber.e("404 + 다른 유저!")
-//
+            Timber.e("404 + 다른 유저!")
+
 //            Handler(Looper.getMainLooper()).post {
 //                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
 //                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
 //                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
 //                context.startActivity(intent)
 //            }
-//        }
-//
-//        if (response.code == 500) {
+        }
+
+        if (response.code == 500) {
 //            runBlocking { logoutUseCase() }
-//            Timber.e("500 + 다른 유저")
-//
+            Timber.e("500 + 다른 유저")
+
 //            Handler(Looper.getMainLooper()).post {
 //                Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
 //                val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
 //                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
 //                context.startActivity(intent)
 //            }
-//        }
+        }
 
         return response
     }

--- a/app/src/main/java/com/eatssu/android/domain/usecase/auth/GetIsAccessTokenValidUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/auth/GetIsAccessTokenValidUseCase.kt
@@ -1,0 +1,13 @@
+package com.eatssu.android.domain.usecase.auth
+
+import com.eatssu.android.data.dto.response.BaseResponse
+import com.eatssu.android.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetIsAccessTokenValidUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(): Flow<BaseResponse<Boolean>> =
+        userRepository.checkUserNameValidation("qkqh") //todo api 만들어지면 수정
+}

--- a/app/src/main/java/com/eatssu/android/presentation/UiEvent.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/UiEvent.kt
@@ -1,0 +1,10 @@
+package com.eatssu.android.presentation
+
+
+/**
+ * 각 Screen에 공통적인 이벤트 타입입니다.
+ * 이벤트 타입을 추가하고 싶다면 UiEvent를 상속받아 사용하세요.
+ */
+interface UiEvent {
+    data class ShowToast(val message: String) : UiEvent
+}

--- a/app/src/main/java/com/eatssu/android/presentation/UiState.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/UiState.kt
@@ -1,0 +1,15 @@
+package com.eatssu.android.presentation
+
+sealed interface UiState<out T> {
+    object Init : UiState<Nothing>
+
+    object Loading : UiState<Nothing>
+
+    data class Success<out T>(
+        val data: T? = null,
+    ) : UiState<T>
+
+    data class Error(
+        val errorMessage: String,
+    ) : UiState<Nothing>
+}

--- a/app/src/main/java/com/eatssu/android/presentation/UiState.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/UiState.kt
@@ -9,7 +9,5 @@ sealed interface UiState<out T> {
         val data: T? = null,
     ) : UiState<T>
 
-    data class Error(
-        val errorMessage: String,
-    ) : UiState<Nothing>
+    object Error : UiState<Nothing>
 }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
@@ -5,6 +5,8 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.eatssu.android.databinding.ActivityIntroBinding
+import com.eatssu.android.presentation.UiEvent
+import com.eatssu.android.presentation.UiState
 import com.eatssu.android.presentation.main.MainActivity
 import com.eatssu.android.presentation.util.showToast
 import com.eatssu.android.presentation.util.startActivity
@@ -26,29 +28,26 @@ class IntroActivity : AppCompatActivity() {
         lifecycleScope.launch {
             introViewModel.uiState.collectLatest { state ->
                 when (state) {
-                    is IntroUiState.Loading -> {
-                        // 할게 없는뎅? 그냥 뷰 보여주기
-                    }
-
-                    is IntroUiState.Success -> {
-                        // 메인 액티비티로 이동
+                    is UiState.Success -> {
                         startActivity<MainActivity>()
                         finish()
                     }
 
-                    is IntroUiState.NoValidToken -> {
+                    is UiState.Error -> {
                         // 로그인 액티비티로 이동
                         startActivity<LoginActivity>()
                         finish()
                     }
+
+                    else -> Unit
                 }
             }
 
             introViewModel.uiEvent.collectLatest { event ->
                 when (event) {
-                    is IntroUiEvent.ShowToast -> {
+                    is UiEvent.ShowToast -> {
                         // 에러 메시지 표시
-                        showToast(event.error)
+                        showToast(event.message)
                     }
                 }
             }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
@@ -20,16 +20,18 @@ class IntroActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_intro)
+        binding = ActivityIntroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        // 일정 시간 지연 이후 실행하기 위한 코드
-        Handler(Looper.getMainLooper()).postDelayed({
+        lifecycleScope.launch {
+            introViewModel.uiState.collectLatest { state ->
+                when (state) {
+                    is IntroUiState.Loading -> {
+                        // 할게 없는뎅? 그냥 뷰 보여주기
+                    }
 
-            introViewModel.autoLogin()
-
-            lifecycleScope.launch {
-                introViewModel.uiState.collectLatest {
-                    if (it.isAutoLogined) {
+                    is IntroUiState.Success -> {
+                        // 메인 액티비티로 이동
                         startActivity<MainActivity>()
 
                         // 이전 키를 눌렀을 때 스플래스 스크린 화면으로 이동을 방지하기 위해

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
@@ -44,9 +44,9 @@ class IntroActivity : AppCompatActivity() {
                 }
             }
 
-            introViewModel.eventState.collectLatest { event ->
+            introViewModel.uiEvent.collectLatest { event ->
                 when (event) {
-                    is IntroEventState.Error -> {
+                    is IntroUiEvent.ShowToast -> {
                         // 에러 메시지 표시
                         showToast(event.error)
                     }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
@@ -1,13 +1,12 @@
 package com.eatssu.android.presentation.login
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import com.eatssu.android.R
+import com.eatssu.android.databinding.ActivityIntroBinding
 import com.eatssu.android.presentation.main.MainActivity
+import com.eatssu.android.presentation.util.showToast
 import com.eatssu.android.presentation.util.startActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -17,6 +16,7 @@ import kotlinx.coroutines.launch
 class IntroActivity : AppCompatActivity() {
 
     private val introViewModel: IntroViewModel by viewModels()
+    private lateinit var binding: ActivityIntroBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,22 +33,25 @@ class IntroActivity : AppCompatActivity() {
                     is IntroUiState.Success -> {
                         // 메인 액티비티로 이동
                         startActivity<MainActivity>()
-
-                        // 이전 키를 눌렀을 때 스플래스 스크린 화면으로 이동을 방지하기 위해
-                        // 이동한 다음 사용안함으로 finish 처리
-                        finish()
-                    } else {
-                        startActivity<LoginActivity>()
-
-                        // 이전 키를 눌렀을 때 스플래스 스크린 화면으로 이동을 방지하기 위해
-                        // 이동한 다음 사용안함으로 finish 처리
                         finish()
                     }
 
+                    is IntroUiState.NoValidToken -> {
+                        // 로그인 액티비티로 이동
+                        startActivity<LoginActivity>()
+                        finish()
+                    }
                 }
             }
 
-        }, 2000) // 시간 2초 이후 실행
-
+            introViewModel.eventState.collectLatest { event ->
+                when (event) {
+                    is IntroEventState.Error -> {
+                        // 에러 메시지 표시
+                        showToast(event.error)
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eatssu.android.domain.usecase.auth.GetAccessTokenUseCase
 import com.eatssu.android.domain.usecase.auth.GetIsAccessTokenValidUseCase
+import com.eatssu.android.presentation.UiEvent
+import com.eatssu.android.presentation.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,11 +21,11 @@ class IntroViewModel @Inject constructor(
     private val getIsAccessTokenValidUseCase: GetIsAccessTokenValidUseCase
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<IntroUiState> = MutableStateFlow(IntroUiState.Loading)
-    val uiState: StateFlow<IntroUiState> = _uiState.asStateFlow()
+    private val _uiState: MutableStateFlow<UiState<IntroState>> = MutableStateFlow(UiState.Init)
+    val uiState: StateFlow<UiState<IntroState>> = _uiState.asStateFlow()
 
-    private val _uiEvent = MutableSharedFlow<IntroUiEvent>()
-    val uiEvent: SharedFlow<IntroUiEvent> = _uiEvent
+    private val _uiEvent = MutableSharedFlow<UiEvent>()
+    val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
     init {
         autoLogin()
@@ -31,21 +33,21 @@ class IntroViewModel @Inject constructor(
 
     private fun autoLogin() {
         viewModelScope.launch {
-            _uiState.value = IntroUiState.Loading
+            _uiState.value = UiState.Loading
 
             try {
                 // 토큰 존재 여부 확인
                 if (getAccessTokenUseCase().isEmpty()) {
-                    _uiState.value = IntroUiState.NoValidToken
-                    _uiEvent.emit(IntroUiEvent.ShowToast("로그인이 필요합니다"))
+                    _uiState.value = UiState.Error
+                    _uiEvent.emit(UiEvent.ShowToast("로그인이 필요합니다"))
                     return@launch
                 }
 
                 checkValid()
 
             } catch (e: Exception) {
-                _uiState.value = IntroUiState.NoValidToken
-                _uiEvent.emit(IntroUiEvent.ShowToast("오류가 발생했습니다: ${e.message}"))
+                _uiState.value = UiState.Error
+                _uiEvent.emit(UiEvent.ShowToast("오류가 발생했습니다: ${e.message}"))
             }
         }
     }
@@ -55,22 +57,16 @@ class IntroViewModel @Inject constructor(
             getIsAccessTokenValidUseCase()
                 .collect {
                     if (it.result == true) { //토큰이 있고 유효함
-                        _uiState.value = IntroUiState.Success
+                        _uiState.value = UiState.Success(IntroState.ValidToken)
                     } else { //토큰이 있어도 유효하지 않음
-                        _uiState.value = IntroUiState.NoValidToken
-                        _uiEvent.emit(IntroUiEvent.ShowToast("로그인이 필요합니다"))
+                        _uiState.value = UiState.Error
+                        _uiEvent.emit(UiEvent.ShowToast("로그인이 필요합니다"))
                     }
                 }
         }
     }
 }
 
-sealed class IntroUiState {
-    object Loading : IntroUiState()
-    object Success : IntroUiState()
-    object NoValidToken : IntroUiState()
-}
-
-sealed class IntroUiEvent {
-    data class ShowToast(val error: String) : IntroUiEvent()
+sealed class IntroState {
+    object ValidToken : IntroState()
 }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
@@ -22,8 +22,8 @@ class IntroViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<IntroUiState> = MutableStateFlow(IntroUiState.Loading)
     val uiState: StateFlow<IntroUiState> = _uiState.asStateFlow()
 
-    private val _eventState = MutableSharedFlow<IntroEventState>()
-    val eventState: SharedFlow<IntroEventState> = _eventState
+    private val _uiEvent = MutableSharedFlow<IntroUiEvent>()
+    val uiEvent: SharedFlow<IntroUiEvent> = _uiEvent
 
     init {
         autoLogin()
@@ -37,7 +37,7 @@ class IntroViewModel @Inject constructor(
                 // 토큰 존재 여부 확인
                 if (getAccessTokenUseCase().isEmpty()) {
                     _uiState.value = IntroUiState.NoValidToken
-                    _eventState.emit(IntroEventState.Error("로그인이 필요합니다"))
+                    _uiEvent.emit(IntroUiEvent.ShowToast("로그인이 필요합니다"))
                     return@launch
                 }
 
@@ -45,7 +45,7 @@ class IntroViewModel @Inject constructor(
 
             } catch (e: Exception) {
                 _uiState.value = IntroUiState.NoValidToken
-                _eventState.emit(IntroEventState.Error("오류가 발생했습니다: ${e.message}"))
+                _uiEvent.emit(IntroUiEvent.ShowToast("오류가 발생했습니다: ${e.message}"))
             }
         }
     }
@@ -58,7 +58,7 @@ class IntroViewModel @Inject constructor(
                         _uiState.value = IntroUiState.Success
                     } else { //토큰이 있어도 유효하지 않음
                         _uiState.value = IntroUiState.NoValidToken
-                        _eventState.emit(IntroEventState.Error("로그인이 필요합니다"))
+                        _uiEvent.emit(IntroUiEvent.ShowToast("로그인이 필요합니다"))
                     }
                 }
         }
@@ -71,6 +71,6 @@ sealed class IntroUiState {
     object NoValidToken : IntroUiState()
 }
 
-sealed class IntroEventState {
-    data class Error(val error: String) : IntroEventState()
+sealed class IntroUiEvent {
+    data class ShowToast(val error: String) : IntroUiEvent()
 }

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
@@ -3,41 +3,74 @@ package com.eatssu.android.presentation.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eatssu.android.domain.usecase.auth.GetAccessTokenUseCase
+import com.eatssu.android.domain.usecase.auth.GetIsAccessTokenValidUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class IntroViewModel @Inject constructor(
-    private val getAccessTokenUseCase: GetAccessTokenUseCase
+    private val getAccessTokenUseCase: GetAccessTokenUseCase,
+    private val getIsAccessTokenValidUseCase: GetIsAccessTokenValidUseCase
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<IntroState> = MutableStateFlow(IntroState())
-    val uiState: StateFlow<IntroState> = _uiState.asStateFlow()
+    private val _uiState: MutableStateFlow<IntroUiState> = MutableStateFlow(IntroUiState.Loading)
+    val uiState: StateFlow<IntroUiState> = _uiState.asStateFlow()
+
+    private val _eventState = MutableSharedFlow<IntroEventState>()
+    val eventState: SharedFlow<IntroEventState> = _eventState
 
     init {
         autoLogin()
     }
 
-    fun autoLogin() {
+    private fun autoLogin() {
         viewModelScope.launch {
-            if (getAccessTokenUseCase().isEmpty()) {
-                _uiState.update { it.copy(isAutoLogined = false) }
-            } else {
-                _uiState.update { it.copy(isAutoLogined = true) }
+            _uiState.value = IntroUiState.Loading
+
+            try {
+                // 토큰 존재 여부 확인
+                if (getAccessTokenUseCase().isEmpty()) {
+                    _uiState.value = IntroUiState.NoValidToken
+                    _eventState.emit(IntroEventState.Error("로그인이 필요합니다"))
+                    return@launch
+                }
+
+                checkValid()
+
+            } catch (e: Exception) {
+                _uiState.value = IntroUiState.NoValidToken
+                _eventState.emit(IntroEventState.Error("오류가 발생했습니다: ${e.message}"))
             }
         }
     }
 
+    private fun checkValid() {
+        viewModelScope.launch {
+            getIsAccessTokenValidUseCase()
+                .collect {
+                    if (it.result == true) { //토큰이 있고 유효함
+                        _uiState.value = IntroUiState.Success
+                    } else { //토큰이 있어도 유효하지 않음
+                        _uiState.value = IntroUiState.NoValidToken
+                        _eventState.emit(IntroEventState.Error("로그인이 필요합니다"))
+                    }
+                }
+        }
+    }
 }
 
-data class IntroState(
-    var toastMessage: String = "",
-    var loading: Boolean = true,
-    var error: Boolean = false,
-    var isAutoLogined: Boolean = false,
-)
+sealed class IntroUiState {
+    object Loading : IntroUiState()
+    object Success : IntroUiState()
+    object NoValidToken : IntroUiState()
+}
+
+sealed class IntroEventState {
+    data class Error(val error: String) : IntroEventState()
+}


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
로딩바를 하려다가... 그러면 UiState에서 Loading을 구분해야하는데 ... 생각해보니 IntroActivity에서는 로딩을 할게 없더라구요. 일단 best practice를 하나 만들어 두면 좋을 것 같아서, `IntroActivity` `IntroViewModel`을 선두로 유리님이 언급하신 SharedFlow를 적용해봤습니다.   

분기처리는 크게 
1. 토큰이 없는 경우  -> NoValidToken -> LoginAcitivity
2. 토큰이 있지만 유효하지 않은 경우 -> NoValidToken -> LoginActivity
3. 토큰이 있고 유효한 경우 -> Success -> MainActivity


기존에는 Intro에서 토큰 유효성 검증은 안하고 토큰 유무만 확인해었습니다!

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

- Handler로 2초 지연하는건 불필요할 거 같아서 뺐어요. uiState 변화 감지해서 화면 이동하는게 맞다고 생각해서 지웠습니다! 
- 말씀하신 SharedFlow가 이게 맞나요??
- 그리고 UiState를 공통 구조를 하나 만들어 놓고 상속해서 쓰는게 나을까요?? 아니면 이렇게 각 화면마다 따로 정의하는게 나을까요? (에러를 빼게 되면 공통되는 구조는 딱히 없지 않을까 싶습니다..!)
- 엑세스 토큰이 유효한지 체크하는 api는 아직 없어서 boolean을 반환하는 api로 일단 꼽아뒀습니다!
- 토큰 인터셉터에서 404 500처리를 잘못해서 이상한 오류가 나는건 아닌가 싶어서, 불필요한 처리가 저기 있는 것 같아 일단 주석처리 했습니다!