### PR TITLE
[Fix] 날짜를 바뀌어도 이전에 선택했던 시간대로 보여지도록 수정 (iOS와 통일)

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/MySharedPreferences.kt
+++ b/app/src/main/java/com/eatssu/android/data/MySharedPreferences.kt
@@ -4,7 +4,6 @@ package com.eatssu.android.data
 import android.content.Context
 import android.content.SharedPreferences
 
-//자동 로그인을 위한 SharedPreferences
 object MySharedPreferences {
     private val MY_ACCOUNT: String = "account"
 
@@ -99,5 +98,15 @@ object MySharedPreferences {
         val prefs: SharedPreferences =
             context.getSharedPreferences(MY_ACCOUNT, Context.MODE_PRIVATE)
         return prefs.getBoolean("ALARM_ON", false)
+    }
+
+    fun savePreTimePosition(context: Context, position: Int) {
+        val prefs = context.getSharedPreferences(MY_ACCOUNT, Context.MODE_PRIVATE)
+        prefs.edit().putInt("PRE_TIME_POSITION", position).apply()
+    }
+
+    fun getPreTimePosition(context: Context): Int {
+        val prefs = context.getSharedPreferences(MY_ACCOUNT, Context.MODE_PRIVATE)
+        return prefs.getInt("PRE_TIME_POSITION", -1)
     }
 }

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaFragment.kt
@@ -10,9 +10,11 @@ import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
+import com.eatssu.android.App
+import com.eatssu.android.data.MySharedPreferences
 import com.eatssu.android.databinding.FragmentCafeteriaBinding
-import com.eatssu.android.presentation.base.BaseFragment
 import com.eatssu.android.presentation.MainViewModel
+import com.eatssu.android.presentation.base.BaseFragment
 import com.eatssu.android.presentation.cafeteria.calendar.CalendarAdapter
 import com.eatssu.android.presentation.cafeteria.calendar.CalendarAdapter.OnItemListener
 import com.eatssu.android.presentation.util.CalendarUtil
@@ -45,10 +47,19 @@ class CafeteriaFragment : BaseFragment<FragmentCafeteriaBinding>(), OnItemListen
 
         val viewpagerFragmentAdapter = CafeteriaViewPagerAdapter(requireActivity())
         viewPager.adapter = viewpagerFragmentAdapter
-        viewPager.setCurrentItem(viewpagerFragmentAdapter.getDefaultFragmentPosition(), false)
+        viewPager.setCurrentItem(
+            viewpagerFragmentAdapter.getDefaultFragmentPosition(App.appContext),
+            false
+        )
 
         val tabTitles = listOf("아침", "점심", "저녁")
         TabLayoutMediator(tabLayout, viewPager) { tab, position -> tab.text = tabTitles[position] }.attach()
+
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                MySharedPreferences.savePreTimePosition(requireContext(), position)
+            }
+        })
 
         initWidgets()
         CalendarUtil.selectedDate = LocalDate.now()

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaViewPagerAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaViewPagerAdapter.kt
@@ -31,7 +31,6 @@ class CafeteriaViewPagerAdapter(fragmentActivity: FragmentActivity) :
     fun getDefaultFragmentPosition(context: Context): Int {
         val savedPosition = MySharedPreferences.getPreTimePosition(context)
         return if (savedPosition in 0..2) savedPosition else {
-            // fallback: 시간 기준
             val time = LocalTime.now()
             when (time.hour) {
                 in 0..9 -> 0

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaViewPagerAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/CafeteriaViewPagerAdapter.kt
@@ -1,10 +1,10 @@
 package com.eatssu.android.presentation.cafeteria
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.eatssu.android.data.MySharedPreferences
 import com.eatssu.android.data.enums.Time
 import com.eatssu.android.presentation.cafeteria.menu.MenuFragment
 import java.time.LocalTime
@@ -12,7 +12,6 @@ import java.time.LocalTime
 class CafeteriaViewPagerAdapter(fragmentActivity: FragmentActivity) :
     FragmentStateAdapter(fragmentActivity) {
 
-    // 1. ViewPager2에 연결할 Fragment 들을 생성
     private val fragmentList = listOf(
         MenuFragment.newInstance(Time.MORNING),
         MenuFragment.newInstance(Time.LUNCH),
@@ -21,33 +20,25 @@ class CafeteriaViewPagerAdapter(fragmentActivity: FragmentActivity) :
 
     lateinit var menuDate : String
 
-    // 2. ViesPager2에서 노출시킬 Fragment 의 갯수 설정
     override fun getItemCount(): Int {
         return fragmentList.size
     }
 
-    // 3. ViewPager2의 각 페이지에서 노출할 Fragment 설정
     override fun createFragment(position: Int): Fragment {
-        /*if(fragmentList[position] is LunchFragment) {
-            (fragmentList[position] as LunchFragment).setDate(menuDate)
-        }*/
         return fragmentList[position]
     }
 
-    // 4. 디폴트로 노출할 Fragment의 위치를 설정
-    @RequiresApi(Build.VERSION_CODES.O)
-    fun getDefaultFragmentPosition(): Int {
-        // 여기에서 디폴트로 노출할 Fragment의 위치를 반환해줍니다.
-        // 예를 들어, 첫 번째 Fragment를 디폴트로 설정하려면 0을 반환합니다.
-
-        val time = LocalTime.now()
-
-        val selectedIndex: Int = when (time.hour) {
-            in 0..9 -> 0 //아침
-            in 10..15 -> 1 //점심
-            in 16..24 -> 2 //저녁
-            else -> 1
+    fun getDefaultFragmentPosition(context: Context): Int {
+        val savedPosition = MySharedPreferences.getPreTimePosition(context)
+        return if (savedPosition in 0..2) savedPosition else {
+            // fallback: 시간 기준
+            val time = LocalTime.now()
+            when (time.hour) {
+                in 0..9 -> 0
+                in 10..15 -> 1
+                in 16..23 -> 2
+                else -> 1
+            }
         }
-        return selectedIndex
     }
 }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
이전에 선택했던 식사 시간대를 저장해서, 날짜를 바뀌어도 그 시간대로 보여지도록 수정 (iOS와 통일)

예시) 현재 시간 점심 대 -> 아침으로 변경 -> 날짜 변동해도 계속 아침으로 나옴

[Screen_recording_20250528_185320.webm](https://github.com/user-attachments/assets/3241de0f-600c-4063-b7bc-c0c45ababbbf)

## Issue

- Resolves #298 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

이게 최선일지....
