### PR TITLE
[Feat] 사진, 갤러리 접근 권한 관련 코드 모두 제거, PickVisualMedia로 마이그레이션

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,13 +9,6 @@
         </intent>
     </queries>
 
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature
@@ -35,12 +28,23 @@
         android:icon="@drawable/img_logo_512"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:requestLegacyExternalStorage="true"
         android:roundIcon="@drawable/img_logo_512"
         android:supportsRtl="true"
         android:theme="@style/Theme.EatSSUAndroid"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+
+        <!-- 사진 접근 관련 : minSDK가 30이상이면 필요없음 -->
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
+
         <meta-data
             android:name="com.google.android.gms.oss.licenses.enabled"
             android:value="true" />
@@ -134,13 +138,6 @@
         </activity>
         <activity
             android:name=".presentation.cafeteria.review.list.ReviewActivity"
-            android:exported="true">
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="" />
-        </activity>
-        <activity
-            android:name=".presentation.mypage.MyPageActivity"
             android:exported="true">
             <meta-data
                 android:name="android.app.lib_name"

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/write/ReviewWriteRateActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/write/ReviewWriteRateActivity.kt
@@ -1,18 +1,14 @@
 package com.eatssu.android.presentation.cafeteria.review.write
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
 import android.widget.Toast
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -55,9 +51,6 @@ class ReviewWriteRateActivity :
         // 현재 메뉴명을 표시합니다.
         binding.menu.text = itemName
 
-        // 외부 저장소에 대한 런타임 퍼미션 요청
-        requestStoragePermission()
-
         setupTextReviewInput()
         setOnClickListener()
 
@@ -69,8 +62,7 @@ class ReviewWriteRateActivity :
         // 이미지 추가 버튼 클릭 리스너 설정
         binding.ibAddPic.setOnClickListener {
             Timber.d("클릭")
-
-            checkPermission()
+            imagePickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         }
 
         binding.btnNextReview2.setOnClickListener {
@@ -162,136 +154,42 @@ class ReviewWriteRateActivity :
         }
     }
 
-
-    // 이미지를 결과값으로 받는 변수
-    private val imageResult = registerForActivityResult(
-        ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        Timber.d("Selected image URI: $uri")
-        uri?.let {
-            try {
-                // 이미지를 불러온다
-                Glide.with(this)
-                    .load(uri)
-                    .fitCenter()
-                    .apply(RequestOptions().override(500, 500))
-                    .into(binding.ivImage)
-
-                binding.ivImage.visibility = View.VISIBLE
-                binding.btnDelete.visibility = View.VISIBLE
-
-                // 임시 파일 생성
-                val inputStream = contentResolver.openInputStream(uri)
-                val tempFile = File(cacheDir, "temp_image_${System.currentTimeMillis()}.jpg")
-                inputStream?.use { input ->
-                    tempFile.outputStream().use { output ->
-                        input.copyTo(output)
-                    }
-                }
-
-                imageFile = tempFile
-                Timber.d("Image loaded successfully to: ${tempFile.absolutePath}")
-            } catch (e: Exception) {
-                Timber.e(e, "Error processing selected image")
-                showToast("이미지 처리 중 오류가 발생했습니다.")
-            }
-        } ?: run {
-            Timber.d("No image selected")
-        }
-    }
-
-    // 갤러리를 부르는 메서드
-    private fun checkPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val readMediaImagePermission = ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.READ_MEDIA_IMAGES
-            )
-
-            if (readMediaImagePermission == PackageManager.PERMISSION_DENIED) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.READ_MEDIA_IMAGES),
-                    PERMISSION_REQUEST_CODE
-                )
-                Timber.e("권한 없음")
-            } else {
-                openGallery()
-            }
+    private val imagePickerLauncher = registerForActivityResult(
+        ActivityResultContracts.PickVisualMedia() // 사진 단일 선택
+    ) { uri ->
+        if (uri != null) {
+            Timber.d("선택된 이미지: $uri")
+            handleImageUri(uri)
         } else {
-            val writePermission = ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE
-            )
-            val readPermission = ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            )
-
-            if (writePermission == PackageManager.PERMISSION_DENIED ||
-                readPermission == PackageManager.PERMISSION_DENIED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                        Manifest.permission.READ_EXTERNAL_STORAGE
-                    ),
-                    PERMISSION_REQUEST_CODE
-                )
-                Timber.e("권한 없음")
-            } else {
-                openGallery()
-            }
+            Timber.d("이미지 선택 안함")
         }
     }
 
-
-    private fun openGallery() {
+    private fun handleImageUri(uri: Uri) {
         try {
-            Timber.d("Opening gallery picker")
-            imageResult.launch("image/*")
+            Glide.with(this)
+                .load(uri)
+                .fitCenter()
+                .apply(RequestOptions().override(500, 500))
+                .into(binding.ivImage)
+
+            binding.ivImage.visibility = View.VISIBLE
+            binding.btnDelete.visibility = View.VISIBLE
+
+            val inputStream = contentResolver.openInputStream(uri)
+            val tempFile = File(cacheDir, "temp_image_${System.currentTimeMillis()}.jpg")
+            inputStream?.use { input ->
+                tempFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            imageFile = tempFile
+            Timber.d("임시 파일 저장 완료: ${tempFile.absolutePath}")
         } catch (e: Exception) {
-            Timber.e(e, "Error opening gallery")
-            showToast("갤러리를 열 수 없습니다.")
+            Timber.e(e, "이미지 처리 중 오류 발생")
+            showToast("이미지 처리 중 오류가 발생했습니다.")
         }
     }
-
-    private fun requestStoragePermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.READ_MEDIA_IMAGES
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.READ_MEDIA_IMAGES),
-                    PERMISSION_REQUEST_CODE
-                )
-            }
-        } else {
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                ) != PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.READ_EXTERNAL_STORAGE
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                        Manifest.permission.READ_EXTERNAL_STORAGE
-                    ),
-                    PERMISSION_REQUEST_CODE
-                )
-            }
-        }
-    }
-
 
     private fun setupTextReviewInput() {
         binding.etReview2Comment.addTextChangedListener(object : TextWatcher {
@@ -316,7 +214,6 @@ class ReviewWriteRateActivity :
         }
     }
 
-
     private fun deleteImage() {
         Timber.d("imageFile: " + imageFile.toString())
         if (imageFile?.exists() == true) {
@@ -332,31 +229,8 @@ class ReviewWriteRateActivity :
         }
     }
 
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        when (requestCode) {
-            PERMISSION_REQUEST_CODE -> {
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    openGallery()
-                } else {
-                    showToast("권한이 거부되어 이미지를 선택할 수 없습니다.")
-                }
-            }
-        }
-    }
-
     private fun showLoading(isLoading: Boolean) {
         binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
         binding.btnNextReview2.visibility = if (isLoading) View.INVISIBLE else View.VISIBLE
-    }
-
-    companion object {
-        // 갤러리 권한 요청
-        const val PERMISSION_REQUEST_CODE = 1
     }
 }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
<img width="939" alt="image" src="https://github.com/user-attachments/assets/4ed23dda-24df-4a65-95da-c8d4a178739b" />

업데이트 거부
사유 : 갤러리앱 같이 사진 권한 모두 필요하지 않는 이상 권한 사용 x -> photoPicker 사용하라고 하네요
2024 11월부터 불필요한 권한 사용하는지에 대한 검사가 빡세졌대요


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

| before | after |
|---|---|
|![Screenshot_20250611_095806](https://github.com/user-attachments/assets/f3ee5951-8a92-47bf-8543-b71b46ed9ad7)|![4](https://github.com/user-attachments/assets/2d3f941b-a808-4a14-ba41-36705fceedcc)|

이제 사진첩 권한 사용 없이 사진1개만 가져올 수 있어요

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ee7df5d2-6b14-4e42-9ac4-cc3cea071fbd"/>


## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

참고 자료
https://developer.android.com/training/data-storage/shared/photopicker
https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html

manifest에 있는 service 관련 코드(백포트)는 minSdk가 29-30으로 높으면 필요가 없는데 저희는 23으로 많이 낮아서
필요하다고 합니다

백포트 선언 : 
- 구버전 기기에서 Google Play Services가 백그라운드에서 Photo Picker 모듈을 자동 설치

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4a228b1f-f8ac-4f7a-a574-7ffa1f1ffb8c" />

[참고](https://developer.android.com/training/data-storage/shared/photopicker#device-availability)

