### PR TITLE
[FIX] Android 8.0 미만 버전 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -185,6 +186,9 @@ dependencies {
     // navigation
     implementation ("androidx.navigation:navigation-fragment:2.8.9")
     implementation ("androidx.navigation:navigation-ui:2.8.9")
+
+    // Android 8.0 미만 버전 대응
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }
 
 kapt {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-appcompat = "1.6.1"
 animation = "1.7.8"
 composeBomVersion = "2025.03.00"
 composeThemeAdapter = "1.2.1"
+desugar_jdk_libs = "2.1.5"
 lifecycleRuntimeKtx = "2.5.2"
 lifecycleViewmodelCompose = "2.8.7"
 material = "1.8.0"
@@ -65,6 +66,7 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref =
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBomVersion" }
 compose-theme-adapter = { module = "com.google.android.material:compose-theme-adapter", version.ref = "composeThemeAdapter" }
+desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 threetenabp = { group = "com.jakewharton.threetenabp", name = "threetenabp", version.ref = "threetenabp" }


### PR DESCRIPTION
## Summary
minSdk를 올리지 않고도 Android 8.0 미만 기기에서 구동될 수 있게 수정 

## Describe your changes
- build.gradle.kts에서 Desugaring 활성화

## To reviewers
- 프로젝트의 minSdk가 23이므로 최소 Android 6.0부터 사용이 가능합니다.
- 그러나 프로젝트에서 Android 8.0부터 도입된 Java 8의 java.time 관련 API를 사용해 Android 8.0 미만 기기에서 실행 하자마자 오류가 발생해 앱이 종료됩니다.
- 구글 공식 문서 [Use Java 8 language features and APIs](https://developer.android.com/studio/write/java8-support) 에 따라 Desugaring 기능을 활성화했습니다.
- 수정 이후 Android 7.0 Pixel 가상 기기에서 크래시 없이 정상 구동 되는 것 확인 했습니다.
- 수정 사항에 따라 LocalDate 관련 접근이 안전해졌으므로 더 이상 불필요한 `@RequiresApi(Build.VERSION_CODES.O)` 어노테이션을 삭제하는 것은 어떻게 하면 좋을까요? Notification API 등으로 RequiresApi 어노테이션이 필요한 경우도 있었습니다.