### PR TITLE
[FIX] 환영 토스트 중복 오류 해결

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -7,7 +7,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.MenuItem
-import android.view.View
 import android.view.View.GONE
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
@@ -32,7 +31,7 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 @AndroidEntryPoint
-class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate){
+class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
 
     private val mainViewModel: MainViewModel by viewModels()
     private val myPageViewModel: MyPageViewModel by viewModels()
@@ -49,6 +48,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
         checkNicknameIsNull()
 
         collectLogoutState()
+        collectUiEvents()
     }
 
     private fun setNavigation() {
@@ -142,14 +142,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
         mainViewModel.checkNameNull()
 
         lifecycleScope.launch {
-            mainViewModel.uiState.collectLatest {
-                if (it.isNicknameNull) {
+            mainViewModel.uiState.collectLatest { state ->
+                if (state is UiState.Success && state.data is MainState.NicknameNull) {
                     //닉네임이 null일 때는 닉네임 설정을 안하면 서비스를 못쓰게 막아야함
                     intent.putExtra("force", true)
                     startActivity<UserNameChangeActivity>()
-                    showToast(it.toastMessage)
-                } else {
-                    showToast(it.toastMessage) //Todo 이게 누구님 반갑습니다. 인데 두번 뜸
                 }
             }
         }
@@ -159,10 +156,20 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     private fun collectLogoutState() {
         lifecycleScope.launch {
             mainViewModel.uiState.collectLatest { state ->
-                if (state.isLoggedOut) {
-                    showToast(state.toastMessage)
+                if (state is UiState.Success && state.data is MainState.LoggedOut) {
                     startActivity<LoginActivity>()
                     finishAffinity()
+                }
+            }
+        }
+    }
+
+    // UiEvent 처리
+    private fun collectUiEvents() {
+        lifecycleScope.launch {
+            mainViewModel.uiEvent.collectLatest { event ->
+                if (event is UiEvent.ShowToast) {
+                    showToast(event.message)
                 }
             }
         }

--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -26,7 +26,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -45,9 +44,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
         setNavigation()
 
         checkAlarmPermission()
-        checkNicknameIsNull()
-
-        collectLogoutState()
+        collectState()
         collectUiEvents()
     }
 
@@ -137,29 +134,24 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     }
 
     // CollectState --
-    private fun checkNicknameIsNull() {
-        Timber.d("관찰 시작")
-        mainViewModel.checkNameNull()
-
+    private fun collectState() {
         lifecycleScope.launch {
             mainViewModel.uiState.collectLatest { state ->
-                if (state is UiState.Success && state.data is MainState.NicknameNull) {
-                    //닉네임이 null일 때는 닉네임 설정을 안하면 서비스를 못쓰게 막아야함
-                    intent.putExtra("force", true)
-                    startActivity<UserNameChangeActivity>()
-                }
-            }
-        }
-    }
+                if (state is UiState.Success) {
+                    when (state.data) {
+                        is MainState.NicknameNull -> {
+                            intent.putExtra("force", true)
+                            startActivity<UserNameChangeActivity>()
+                        }
 
-    // 로그아웃 처리
-    private fun collectLogoutState() {
-        lifecycleScope.launch {
-            mainViewModel.uiState.collectLatest { state ->
-                if (state is UiState.Success && state.data is MainState.LoggedOut) {
-                    startActivity<LoginActivity>()
-                    finishAffinity()
-                }
+                        is MainState.LoggedOut -> {
+                            startActivity<LoginActivity>()
+                            finishAffinity()
+                        }
+
+                        else -> Unit
+                    }
+                } else Unit
             }
         }
     }

--- a/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.presentation
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -11,14 +10,14 @@ import com.eatssu.android.domain.usecase.auth.GetUserInfoUseCase
 import com.eatssu.android.domain.usecase.auth.LogoutUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.time.LocalDate
@@ -31,8 +30,11 @@ class MainViewModel @Inject constructor(
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<MainState> = MutableStateFlow(MainState())
-    val uiState: StateFlow<MainState> = _uiState.asStateFlow()
+    private val _uiState: MutableStateFlow<UiState<MainState>> = MutableStateFlow(UiState.Init)
+    val uiState: StateFlow<UiState<MainState>> = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<UiEvent>()
+    val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
 //    init {
 //        checkNameNull()
@@ -41,38 +43,31 @@ class MainViewModel @Inject constructor(
     fun checkNameNull() {
         viewModelScope.launch {
             getUserInfoUseCase().onStart {
-                _uiState.update { it.copy(loading = true) }
-            }.onCompletion {
-                _uiState.update { it.copy(loading = false, error = true) }
+                _uiState.value = UiState.Loading
             }.catch { e ->
-                _uiState.update {
-                    it.copy(
-                        error = true,
-                        toastMessage = context.getString(R.string.not_found)
-                    )
-                }
+                _uiState.value = UiState.Error
+                _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.not_found)))
                 Timber.e(e.toString())
             }.collectLatest { result ->
                 Timber.d(result.toString())
                 result.result?.apply {
-                    if (this.nickname.isNullOrBlank()) {
-                        _uiState.update {
-                            it.copy(
-                                isNicknameNull = true,
-                                toastMessage = context.getString(R.string.set_nickname)
-                            )
-                        }
-                    } else {
-                        _uiState.update {
-                            it.copy(
-                                isNicknameNull = false,
-                                toastMessage = String.format(
-                                    context.getString(R.string.hello_user),
-                                    this.nickname
-                                )
-                            )
-                        }
+                    val nickname = this.nickname
+
+                    if (nickname.isNullOrBlank()) {
+                        _uiState.value = UiState.Success(MainState.NicknameNull)
+                        _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.set_nickname)))
+                        return@apply
                     }
+
+                    _uiState.value = UiState.Success(MainState.NicknameExists(nickname))
+                    _uiEvent.emit(
+                        UiEvent.ShowToast(
+                            String.format(
+                                context.getString(R.string.hello_user),
+                                nickname
+                            )
+                        )
+                    )
                 }
             }
         }
@@ -82,12 +77,8 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             logoutUseCase() //Todo 반환값이 쓰이는게 아니면 이렇게 해도 되나?
 
-            _uiState.update {
-                it.copy(
-                    toastMessage = context.getString(R.string.logout_description),
-                    isLoggedOut = true
-                )
-            }
+            _uiState.value = UiState.Success(MainState.LoggedOut)
+            _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.logout_description)))
         }
     }
 
@@ -106,10 +97,8 @@ class MainViewModel @Inject constructor(
 }
 
 
-data class MainState(
-    var loading: Boolean = true,
-    var error: Boolean = false,
-    var toastMessage: String = "",
-    var isNicknameNull: Boolean = false,
-    var isLoggedOut: Boolean = false,
-)
+sealed class MainState {
+    object NicknameNull : MainState()
+    data class NicknameExists(val nickname: String) : MainState()
+    object LoggedOut : MainState()
+}

--- a/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
@@ -50,13 +50,13 @@ class MainViewModel @Inject constructor(
                 Timber.e(e.toString())
             }.collectLatest { result ->
                 Timber.d(result.toString())
-                result.result?.apply {
-                    val nickname = this.nickname
+                result.result?.let { userInfo ->
+                    val nickname = userInfo.nickname
 
                     if (nickname.isNullOrBlank()) {
                         _uiState.value = UiState.Success(MainState.NicknameNull)
                         _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.set_nickname)))
-                        return@apply
+                        return@let
                     }
 
                     _uiState.value = UiState.Success(MainState.NicknameExists(nickname))

--- a/app/src/main/java/com/eatssu/android/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/LoginViewModel.kt
@@ -57,7 +57,6 @@ class LoginViewModel @Inject constructor(
                         setUserEmailUseCase(email)
 
                         _uiState.value = UiState.Success(LoginState.LoginSuccess)
-                        _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.login_done)))
 
                         TokenStateManager.setTokenValid()
                     }

--- a/app/src/main/java/com/eatssu/android/presentation/util/ContextUtil.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/util/ContextUtil.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.Fragment
 
 // Activity
 fun Context.showToast(msg: String) {
-    //Todo 앱 진입시 빈 토스트 왜 뜨는지 알아야함
     if (msg.isNotEmpty()) {
         Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
     }


### PR DESCRIPTION
## Summary
MainViewModel에서 MutableStateFlow 하나로 관리하던 토스트를 MutableSharedFlow로 분리

## Describe your changes
 - MainViewModel에 UiEvent, UiState 적용
 - 이벤트와 상태 변화 분리
 - TODO 코멘트 삭제
 - LoginViewModel에서 중복으로 띄우는 환영합니다 토스트 제거

## Issue
- Resolves #274

## To reviewers
빈 토스트가 띄워지는 이유는 MainState의 loading, error 값이 바뀔 때 toastMessage 값으로 토스트를 보내서였습니다. Flow를 분리해 해결했습니다.

UiState의 Error 타입이 아무런 값을 가지고 있지 않은데, UiState<TSuccess, TError> 처럼 제네릭 타입을 2개로 하면 MainState.NicknameNull과 같이 오류지만 어떤 결과가 나왔을 때 코드가 더 깔끔할 것 같습니다.

다만 UiState를 수정하면 변경 사항이 커지기에, 모든 Activity와 ViewModel에 Flow 분리를 진행한 후 하면 좋을 것 같습니다.