### PR TITLE
[Feat] AGP를 8.12.2로 업그레이드

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanistAppcompatTheme = "0.16.0"
 activityCompose = "1.9.2"
-android = "8.6.1"
+android = "8.12.2"
 androidx-core = "1.7.0"
 androidx-appcompat = "1.6.1"
 lifecycleRuntimeCompose = "2.8.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Feb 17 11:26:14 KST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
Android Studio의 AGP Upgrade Assistant를 사용해 AGP를 8.12.2로 업그레이드 했습니다. 

## Issue

- Resolves #337