### PR TITLE
[Fix] Github Action으로 APK 빌드 후 슬랙 업로드

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    
+
     - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
@@ -41,18 +41,34 @@ jobs:
         KAKAO_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
         NAVER_MAPS_CLIENT_ID: ${{ secrets.NAVER_MAPS_CLIENT_ID }}
 
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+
       run: |
         echo DEV_BASE_URL=\"$DEV_BASE_URL\" >> local.properties
         echo PROD_BASE_URL=\"$PROD_BASE_URL\" >> local.properties
         echo KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY >> local.properties
         echo NAVER_MAPS_CLIENT_ID=$NAVER_MAPS_CLIENT_ID >> local.properties
-  
+        
+        echo KEY_ALIAS=$KEY_ALIAS >> local.properties
+        echo KEY_PASSWORD=$KEY_PASSWORD >> local.properties
+        echo KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD >> local.properties
+        echo KEYSTORE_FILE=eatssu.keystore >> local.properties
+
     - name: Generate google-services.json
       run: |
         echo "$GOOGLE_SERVICE" > app/google-services.json.b64
         base64 -d -i app/google-services.json.b64 > app/google-services.json
       env:
         GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE }}
+
+    - name: Generate eatssu.keystore
+      env:
+        KEYSTORE_CONTENT: ${{ secrets.KEYSTORE_CONTENT }}
+      run: |
+        echo "$KEYSTORE_CONTENT" > app/eatssu.keystore.b64
+        base64 -d -i app/eatssu.keystore.b64 > app/eatssu.keystore
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/qa_apk.yml
+++ b/.github/workflows/qa_apk.yml
@@ -63,7 +63,7 @@ jobs:
       run: ./gradlew assembleDebug --stacktrace
 
     - name: Upload APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: app
         path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/qa_apk.yml
+++ b/.github/workflows/qa_apk.yml
@@ -1,7 +1,7 @@
 name: Android APK Build and Slack Upload
 
 on:
-  workflow_dispatch:  # 버튼을 누를 시 실행되도록 설정
+  workflow_dispatch: # 버튼을 누를 시 실행되도록 설정
     inputs:
       buildVariant:
         description: 'Build Variant'
@@ -28,48 +28,48 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
 
-    - name: Create Local Properties
-      run: touch local.properties
+      - name: Create Local Properties
+        run: touch local.properties
 
-    - name: Access Local Properties
-      env:
-        DEV_BASE_URL: ${{ secrets.DEV_BASE_URL }}
-        PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
-        KAKAO_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
-        NAVER_MAPS_CLIENT_ID: ${{ secrets.NAVER_MAPS_CLIENT_ID }}
+      - name: Access Local Properties
+        env:
+          DEV_BASE_URL: ${{ secrets.DEV_BASE_URL }}
+          PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
+          KAKAO_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          NAVER_MAPS_CLIENT_ID: ${{ secrets.NAVER_MAPS_CLIENT_ID }}
 
-      run: |
-        echo DEV_BASE_URL=\"$DEV_BASE_URL\" >> local.properties
-        echo PROD_BASE_URL=\"$PROD_BASE_URL\" >> local.properties
-        echo KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY >> local.properties
-        echo NAVER_MAPS_CLIENT_ID=$NAVER_MAPS_CLIENT_ID >> local.properties
+        run: |
+          echo DEV_BASE_URL=\"$DEV_BASE_URL\" >> local.properties
+          echo PROD_BASE_URL=\"$PROD_BASE_URL\" >> local.properties
+          echo KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY >> local.properties
+          echo NAVER_MAPS_CLIENT_ID=$NAVER_MAPS_CLIENT_ID >> local.properties
 
-    - name: Generate google-services.json
-      run: |
-        echo "$GOOGLE_SERVICE" > app/google-services.json.b64
-        base64 -d -i app/google-services.json.b64 > app/google-services.json
-      env:
-        GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE }}
+      - name: Generate google-services.json
+        run: |
+          echo "$GOOGLE_SERVICE" > app/google-services.json.b64
+          base64 -d -i app/google-services.json.b64 > app/google-services.json
+        env:
+          GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE }}
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
       - name: Set Distribution Target
         id: set-target
@@ -83,27 +83,27 @@ jobs:
       - name: Build APK
         run: ./gradlew assemble${{ env.VARIANT }}
 
-    - name: Upload APK
-      uses: actions/upload-artifact@v4
-      with:
-        name: app
-        path: app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk
 
-    - name: Slack - Send Msg
-      uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: workflow,commit,repo,author,job,ref,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Slack - Send Msg
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: workflow,commit,repo,author,job,ref,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-    - name: Slack - Upload APK
-      if: github.event_name == 'workflow_dispatch'
-      uses: MeilCli/slack-upload-file@v4
-      with:
-        slack_token: ${{ secrets.SLACK_TOKEN }}
-        channel_id: ${{ secrets.SLACK_CHANNEL }}
-        initial_comment: '${{ github.event.inputs.branch }} 브랜치의 ${{ github.event.inputs.buildVariant }} Variant APK 빌드가 완료되었습니다.'
-        file_type: 'apk'
-        file_name: 'app-${{ github.event.inputs.buildVariant }}.apk'
-        file_path: './app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk'
+      - name: Slack - Upload APK
+        if: github.event_name == 'workflow_dispatch'
+        uses: MeilCli/slack-upload-file@v4
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel_id: ${{ secrets.SLACK_CHANNEL }}
+          initial_comment: '${{ github.event.inputs.branch }} 브랜치의 ${{ github.event.inputs.buildVariant }} Variant APK 빌드가 완료되었습니다.'
+          file_type: 'apk'
+          file_name: 'app-${{ github.event.inputs.buildVariant }}.apk'
+          file_path: './app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk'

--- a/.github/workflows/qa_apk.yml
+++ b/.github/workflows/qa_apk.yml
@@ -55,11 +55,20 @@ jobs:
           KAKAO_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
           NAVER_MAPS_CLIENT_ID: ${{ secrets.NAVER_MAPS_CLIENT_ID }}
 
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+
         run: |
           echo DEV_BASE_URL=\"$DEV_BASE_URL\" >> local.properties
           echo PROD_BASE_URL=\"$PROD_BASE_URL\" >> local.properties
           echo KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY >> local.properties
           echo NAVER_MAPS_CLIENT_ID=$NAVER_MAPS_CLIENT_ID >> local.properties
+          
+          echo KEY_ALIAS=$KEY_ALIAS >> local.properties
+          echo KEY_PASSWORD=$KEY_PASSWORD >> local.properties
+          echo KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD >> local.properties
+          echo KEYSTORE_FILE=eatssu.keystore >> local.properties
 
       - name: Generate google-services.json
         run: |
@@ -67,6 +76,13 @@ jobs:
           base64 -d -i app/google-services.json.b64 > app/google-services.json
         env:
           GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE }}
+
+      - name: Generate eatssu.keystore
+        env:
+          KEYSTORE_CONTENT: ${{ secrets.KEYSTORE_CONTENT }}
+        run: |
+          echo "$KEYSTORE_CONTENT" > app/eatssu.keystore.b64
+          base64 -d -i app/eatssu.keystore.b64 > app/eatssu.keystore
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/qa_apk.yml
+++ b/.github/workflows/qa_apk.yml
@@ -44,10 +44,13 @@ jobs:
         DEV_BASE_URL: ${{ secrets.DEV_BASE_URL }}
         PROD_BASE_URL: ${{ secrets.PROD_BASE_URL }}
         KAKAO_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+        NAVER_MAPS_CLIENT_ID: ${{ secrets.NAVER_MAPS_CLIENT_ID }}
+
       run: |
         echo DEV_BASE_URL=\"$DEV_BASE_URL\" >> local.properties
         echo PROD_BASE_URL=\"$PROD_BASE_URL\" >> local.properties
-        echo KAKAO_NATIVE_APP_KEY=$KAKAO_APP_KEY >> local.properties
+        echo KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY >> local.properties
+        echo NAVER_MAPS_CLIENT_ID=$NAVER_MAPS_CLIENT_ID >> local.properties
 
     - name: Generate google-services.json
       run: |

--- a/.github/workflows/qa_apk.yml
+++ b/.github/workflows/qa_apk.yml
@@ -3,21 +3,30 @@ name: Android APK Build and Slack Upload
 on:
   workflow_dispatch:  # 버튼을 누를 시 실행되도록 설정
     inputs:
-      environment:
-        description: 'Select environment'
+      buildVariant:
+        description: 'Build Variant'
         required: true
-        default: 'qa'
+        default: 'debug'
         type: choice
         options:
-          - qa
-          - production
+          - debug
+          - release
+      branch:
+        description: '빌드할 브랜치'
+        required: true
+        default: 'develop'
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
 
     - name: Cache Gradle packages
       uses: actions/cache@v4
@@ -62,14 +71,23 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build Debug APK
-      run: ./gradlew assembleDebug --stacktrace
+      - name: Set Distribution Target
+        id: set-target
+        run: |
+          if [[ "${{ github.event.inputs.buildVariant }}" == "debug" ]]; then
+            echo "VARIANT=Debug" >> $GITHUB_ENV
+          else
+            echo "VARIANT=Release" >> $GITHUB_ENV
+          fi
+
+      - name: Build APK
+        run: ./gradlew assemble${{ env.VARIANT }}
 
     - name: Upload APK
       uses: actions/upload-artifact@v4
       with:
         name: app
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk
 
     - name: Slack - Send Msg
       uses: 8398a7/action-slack@v3
@@ -85,7 +103,7 @@ jobs:
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         channel_id: ${{ secrets.SLACK_CHANNEL }}
-        initial_comment: 'APK 빌드가 완료되었습니다.'
+        initial_comment: '${{ github.event.inputs.branch }} 브랜치의 ${{ github.event.inputs.buildVariant }} Variant APK 빌드가 완료되었습니다.'
         file_type: 'apk'
-        file_name: 'app-debug.apk'
-        file_path: './app/build/outputs/apk/debug/app-debug.apk'
+        file_name: 'app-${{ github.event.inputs.buildVariant }}.apk'
+        file_path: './app/build/outputs/apk/${{ github.event.inputs.buildVariant }}/app-${{ github.event.inputs.buildVariant }}.apk'

--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,8 @@ captures/
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,18 @@ android {
         compose = true
     }
 
+    signingConfigs {
+        val p = Properties()
+        p.load(project.rootProject.file("local.properties").reader())
+
+        create("release") {
+            keyAlias = p.getProperty("KEY_ALIAS")
+            keyPassword = p.getProperty("KEY_PASSWORD")
+            storeFile = file(p.getProperty("KEYSTORE_FILE"))
+            storePassword = p.getProperty("KEYSTORE_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             val p = Properties()
@@ -55,6 +67,8 @@ android {
             isShrinkResources = false
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+
+            signingConfig = signingConfigs["release"]
         }
 
         debug {


### PR DESCRIPTION
## Summary
Github Action에서 브랜치, Build Variant를 지정해 빌드 요청하면 슬랙으로 APK를 업로드할 수 있게 수정했습니다.
Release 모드의 Signed APK를 기존 방식이 아니라 gradle task로 만들 수 있도록 수정했습니다.

TODO: Firebase App Distribution을 사용해 자동으로 베타 테스터들에게 APK 배포하기

## Describe your changes
<img width="775" height="539" alt="image" src="https://github.com/user-attachments/assets/0ec25001-f3f2-4aee-9ba9-ddb061a01d31" />

- Android APK Build and Slack Upload 에서 빌드할 브랜치, Build Variant(debug, release)를 고르고 빌드할 수 있게 변경했습니다.
- build.gradle.kts에서 release signingConfig를 추가했습니다. 이 때 Keystore 정보는 local.properties에서 가져옵니다.
- .gitignore 에 모든 keystore 파일을 무시하도록 추가했습니다.

## Issue

- Resolves #336 
- Resolves #279

## To reviewers
- 이 PR이 머지되면 앞으로 빌드할 때 local.properties 를 제가 수정한 노션대로 다시 변경해야 합니다.
KEY_ALIAS, KEY_PASSWORD, KEYSTORE_FILE, KEYSTORE_PASSWORD 라는 프로퍼티를 새로 만들고 기존 빌드할 때 사용했던 값을 집어 넣으면 됩니다.
google-services.json처럼 eatssu.keystore라는 파일에 Keystore 파일을 두면 자동으로 Signed APK를 만들 수 있습니다.

- Github Action Secret에 KEY_ALIAS, KEY_PASSWORD, KEYSTORE_PASSWORD와 Base64로 Keystore 값을 인코딩한 KEYSTORE_CONTENT를 추가했습니다. 이후 Github Action이 실행되면서 KEYSTORE_CONTENT의 값을 디코딩 한 후, eatssu.keystore에 저장합니다. google-services.json과 같은 방식으로 제작했습니다.
