### PR TITLE
[Feat] Firebase Cloud Messaging 도입

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,6 +180,7 @@ dependencies {
     implementation(libs.firebase.config)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.messaging)
 
     // Timber for logging
     implementation(libs.timber)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,23 @@
                 android:resource="@xml/widget_info" />
         </receiver>
 
+        <!--   Firebase Cloud Messaging     -->
+        <service
+                android:name=".alarm.EatSsuFirebaseMessagingService"
+                android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <!-- 기본 알림 아이콘과 색상 설정 -->
+        <meta-data
+                android:name="com.google.firebase.messaging.default_notification_icon"
+                android:resource="@drawable/ic_mini_logo" />
+        <meta-data
+                android:name="com.google.firebase.messaging.default_notification_color"
+                android:resource="@color/primary" />
+
 
         <!--    워커 매니저를 위한 프로바이더    -->
         <provider

--- a/app/src/main/java/com/eatssu/android/alarm/EatSsuFirebaseMessagingService.kt
+++ b/app/src/main/java/com/eatssu/android/alarm/EatSsuFirebaseMessagingService.kt
@@ -1,0 +1,77 @@
+package com.eatssu.android.alarm
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.eatssu.android.R
+import com.eatssu.android.presentation.login.IntroActivity
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import timber.log.Timber
+
+
+class EatSsuFirebaseMessagingService : FirebaseMessagingService() {
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        Timber.d("From: ${remoteMessage.from}")
+
+        val notificationBody = remoteMessage.notification?.body ?: return
+        Timber.d("Message Notification Body: $notificationBody")
+
+        sendNotification(notificationBody)
+    }
+
+
+    override fun onNewToken(token: String) {
+        Timber.d("Refreshed token: $token")
+        // 아직 특정 기기의 Push Token이 필요하지 않음
+    }
+
+    private fun sendNotification(messageBody: String?) {
+        val notificationManager =
+            getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "서버가 보낸 알림",
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = "잇슈 서버가 보낸 알림을 표시합니다."
+            enableLights(true)
+            enableVibration(true)  // 진동도 활성화
+            lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC // 잠금 화면에서도 표시
+        }
+        notificationManager.createNotificationChannel(channel)
+
+        val intent = Intent(this, IntroActivity::class.java).apply {
+            putExtra("launch_path", "notification")
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification =
+            NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_mini_logo)
+                .setContentText(messageBody)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_EVENT)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .build()
+
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "FCMNotificationChannel"
+        private const val NOTIFICATION_ID = 2
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 play-services-base = { group = "com.google.android.gms", name = "play-services-base", version.ref = "play-services-base" }
 
 # etc


### PR DESCRIPTION
## Summary
학교 축제로 특식 관련된 알림을 보내야 하는 상황에, 앱을 켜고 있지 않더라도 서버로부터 알림을 수신한 뒤 보여주는 기능을 구현했습니다. 

## Describe your changes
<img width="240" height="604" alt="Screenshot_20250916_175205" src="https://github.com/user-attachments/assets/f4404305-7268-4cd4-9841-be46655fd6c1" />


## To reviewers
- Firebase Console의 [Messaging](https://console.firebase.google.com/u/0/project/eat-ssu-2023/messaging) 기능 > 메시지 유형은 Firebase 알림 메시지 > 타겟을 앱 + 안드로이드로 지정하면 정상적으로 알림이 수신됩니다.
<img width="528" height="440" alt="image" src="https://github.com/user-attachments/assets/d000de04-3f93-4ddd-8cae-8c42ab63fccd" />

- 테스트해보았을 때 평균적으로 알림 수신까지 1분이 걸려요!