### PR TITLE
[Chore] 닉네임이 "user-"로 시작하면 닉네임 설정화면으로 이동하게 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eatssu.android.R
 import com.eatssu.android.domain.repository.UserRepository
-import com.eatssu.android.domain.usecase.user.GetUserNickNameUseCase
 import com.eatssu.android.domain.usecase.auth.LogoutUseCase
 import com.eatssu.android.domain.usecase.user.GetUserCollegeDepartmentUseCase
+import com.eatssu.android.domain.usecase.user.GetUserNickNameUseCase
 import com.eatssu.android.domain.usecase.user.SetUserCollegeDepartmentUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -42,12 +42,9 @@ class MainViewModel @Inject constructor(
     private val _uiEvent = MutableSharedFlow<UiEvent>()
     val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
-//    init {
-//        checkNameNull()
-//    } 얘 떄문에 두번씩 처리됨.
-
     init {
         getUserDepartment()
+        fetchAndCheckNickname()
     }
 
     fun refreshUserDepartment() {
@@ -72,7 +69,7 @@ class MainViewModel @Inject constructor(
                 result.result?.let { userInfo ->
                     val nickname = userInfo.nickname
 
-                    if (nickname.isNullOrBlank()) {
+                    if (nickname.isNullOrBlank() || nickname.startsWith("user-")) {
                         _uiState.value = UiState.Success(MainState.NicknameNull)
                         _uiEvent.emit(UiEvent.ShowToast(context.getString(R.string.set_nickname)))
                         return@let


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
닉네임이 "user-"로 시작하면 닉네임 설정화면으로 이동하게 수정하였습니다.




## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

잇슈 초창기에는 기본 닉네임이 없었습니다.
닉네임이 없는 상태에서 빈틈이 생겨 NPE이 빈번하게 일어났고, 이에 대한 대책으로 디폴트 닉네임을 "user-xxxx"와 같이 설정하게 되었습니다. 하지만 디폴트 닉네임이 너무 못생긴 관계로, "수영하는 원숭이" 와 같이 재치있는 이름으로 바꾸자는 이야기도 나왔으나, 백엔드 작업이 지연되고 있어 "user-"로 시작되는 닉네임의 경우 닉네임 변경을 강제하도록 조건문을 추가하였습니다.

https://github.com/EAT-SSU/Server/issues/123


