### PR TITLE
[Feat] BottomBar 여백 오류 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
@@ -9,12 +9,29 @@ import android.content.pm.PackageManager
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,8 +48,8 @@ import com.eatssu.android.presentation.MainState
 import com.eatssu.android.presentation.MainViewModel
 import com.eatssu.android.presentation.UiEvent
 import com.eatssu.android.presentation.UiState
-import com.eatssu.android.presentation.map.component.FilterType
 import com.eatssu.android.presentation.map.component.DepartmentBottomSheet
+import com.eatssu.android.presentation.map.component.FilterType
 import com.eatssu.android.presentation.map.component.MapRestaurantBottomSheet
 import com.eatssu.android.presentation.map.component.PartnershipFilterToggle
 import com.eatssu.android.presentation.map.model.PlaceType
@@ -42,7 +59,15 @@ import com.eatssu.design_system.theme.Black
 import com.eatssu.design_system.theme.EatssuTheme
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
-import com.naver.maps.map.compose.*
+import com.naver.maps.map.compose.Align
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapUiSettings
+import com.naver.maps.map.compose.Marker
+import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.rememberCameraPositionState
+import com.naver.maps.map.compose.rememberMarkerState
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import kotlinx.coroutines.flow.collectLatest
@@ -249,7 +274,7 @@ fun MapFragmentComposeView(
                 cameraPositionState = cameraPositionState,
                 uiSettings = MapUiSettings(isZoomControlEnabled = false, isLocationButtonEnabled = true),
                 locationSource = locationSource,
-                contentPadding = PaddingValues(bottom = 60.dp),
+                contentPadding = PaddingValues(bottom = dimensionResource(R.dimen.bottom_nav_height)),
                 properties = MapProperties(
                     locationTrackingMode = LocationTrackingMode.Follow,
                 ),

--- a/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
@@ -249,6 +249,7 @@ fun MapFragmentComposeView(
                 cameraPositionState = cameraPositionState,
                 uiSettings = MapUiSettings(isZoomControlEnabled = false, isLocationButtonEnabled = true),
                 locationSource = locationSource,
+                contentPadding = PaddingValues(bottom = 60.dp),
                 properties = MapProperties(
                     locationTrackingMode = LocationTrackingMode.Follow,
                 ),

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/bottom_navi_bar"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:navGraph="@navigation/eatssu_navigation"/>

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/gray100"
+    android:paddingBottom="60dp"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
@@ -12,6 +13,5 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         tools:listitem="@layout/item_cafeteria_section" />
-
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/gray100"
-    android:paddingBottom="60dp"
+    android:paddingBottom="@dimen/bottom_nav_height"
     android:clipToPadding="false"
     android:orientation="vertical">
 

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:background="@color/gray100"
     android:paddingBottom="60dp"
+    android:clipToPadding="false"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -32,7 +32,9 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@+id/toolbar"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:paddingBottom="60dp"
+        android:clipToPadding="false">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -33,7 +33,7 @@
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@+id/toolbar"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:paddingBottom="60dp"
+        android:paddingBottom="@dimen/bottom_nav_height"
         android:clipToPadding="false">
 
         <LinearLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 바텀 네비바 높이 만큼의 패딩 -->
+    <dimen name="bottom_nav_height">60dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
- 바텀바 라운드 디자인 도입 후 바텀네비바에 RoundCorner가 적용되어 있는데 뒷부분이 자연스럽지 않습니다.
<img width="656" height="206" alt="Screenshot 2025-09-21 at 1 58 44 PM" src="https://github.com/user-attachments/assets/582dd275-aa72-4c1b-b484-bf4464d8d0b6" />


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

< 피그마 디자인 >
<img width="366" height="181" alt="Screenshot 2025-09-21 at 1 57 42 PM" src="https://github.com/user-attachments/assets/a1ac7462-b83c-4f11-a8a4-cfe12fa20c91" />
- 디자인 의도 자체가 기존 화면에서 바텀바가 둥둥 떠있는 느낌인 것 같았습니다.
- MainActivity 내 Fragment 영역을 화면 맨 하단까지 확장했습니다.
- 이에 맞춰서 각각의 fragment 화면 내부에 padding을 bottomBar의 높이인 60dp만큼씩 추가했습니다.



https://github.com/user-attachments/assets/04cfa271-7fa4-48dc-b90e-e278f516881d




## Issue

- Resolves #356 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

