### PR TITLE
[Feat] 내정보 수정 > EditText 입력 오류 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -1,6 +1,8 @@
 package com.eatssu.android.presentation.mypage.userinfo
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -56,24 +58,28 @@ class UserInfoActivity :
             }
         }
 
-        // TextWatcher → doAfterTextChanged 로 교체
-        binding.etChNickname.doAfterTextChanged { editable ->
-            inputNickname = editable?.toString()?.trim().orEmpty()
-            val isValidLength = inputNickname.length in 2..8
-            val isNicknameChanged =
-                inputNickname != userInfoViewModel.uiState.value.originalNickname
+        binding.etChNickname.addTextChangedListener(object : TextWatcher {
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                inputNickname = binding.etChNickname.text.trim().toString()
+                val nicknameLength = inputNickname.length
+                val isValidLength = nicknameLength in 2..8
+                val isNicknameChanged = inputNickname != userInfoViewModel.uiState.value.originalNickname
 
-            binding.btnCheckNicknameDuplication.isEnabled = isValidLength && isNicknameChanged
-            binding.btnComplete.isEnabled = false
+                binding.btnCheckNicknameDuplication.isEnabled = isValidLength && isNicknameChanged
+                binding.btnComplete.isEnabled = false
 
-            if (!isValidLength && inputNickname.isNotEmpty()) {
-                binding.tvNickname28.setTextColor(getColor(R.color.error))
-                binding.tvNickname28.text = getString(R.string.set_nickname_2_8)
-                binding.etChNickname.setBackgroundResource(R.drawable.shape_text_field_small_red)
-            } else {
-                binding.tvNickname28.setTextColor(getColor(R.color.gray600))
+                if (!isValidLength && inputNickname.isNotEmpty()) {
+                    binding.tvNickname28.setTextColor(getColor(R.color.error))
+                    binding.tvNickname28.text = getString(R.string.set_nickname_2_8)
+                    binding.etChNickname.setBackgroundResource(R.drawable.shape_text_field_small_red)
+                } else {
+                    binding.tvNickname28.setTextColor(getColor(R.color.gray600))
+                }
             }
-        }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(p0: Editable?) {}
+        })
 
         setOnCheckNicknameDuplicationClickListener()
         setCollegeDepartmentClickListener()

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -1,8 +1,6 @@
 package com.eatssu.android.presentation.mypage.userinfo
 
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,6 +8,7 @@ import android.view.WindowManager
 import android.widget.PopupWindow
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -43,43 +42,40 @@ class UserInfoActivity :
 
         force = intent.getBooleanExtra("force", false)
 
-        binding.btnCheckNickname.isEnabled = false
+        binding.btnCheckNicknameDuplication.isEnabled = false
         binding.btnComplete.isEnabled = false
 
         lifecycleScope.launch {
-            userInfoViewModel.uiState.collectLatest {
-                binding.etChNickname.setText(it.nickname)
-                binding.tvCollege.text = it.selectedCollege.collegeName
-                binding.tvDepartment.text = it.selectedDepartment.departmentName
+            userInfoViewModel.uiState.collectLatest { state ->
+                if (binding.etChNickname.text.toString() != state.nickname) {
+                    binding.etChNickname.setText(state.nickname)
+                    binding.etChNickname.setSelection(state.nickname.length) // 커서 끝으로 이동
+                }
+                binding.tvCollege.text = state.selectedCollege.collegeName
+                binding.tvDepartment.text = state.selectedDepartment.departmentName
             }
         }
 
-        binding.etChNickname.addTextChangedListener(object : TextWatcher {
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                inputNickname = binding.etChNickname.text.trim().toString()
-                val nicknameLength = inputNickname.length
-                val isValidLength = nicknameLength in 2..8
-                val isNicknameChanged = inputNickname != userInfoViewModel.uiState.value.originalNickname
+        // TextWatcher → doAfterTextChanged 로 교체
+        binding.etChNickname.doAfterTextChanged { editable ->
+            inputNickname = editable?.toString()?.trim().orEmpty()
+            val isValidLength = inputNickname.length in 2..8
+            val isNicknameChanged =
+                inputNickname != userInfoViewModel.uiState.value.originalNickname
 
-                binding.btnCheckNickname.isEnabled = isValidLength && isNicknameChanged
-                binding.btnComplete.isEnabled = false
+            binding.btnCheckNicknameDuplication.isEnabled = isValidLength && isNicknameChanged
+            binding.btnComplete.isEnabled = false
 
-                if (!isValidLength && inputNickname.isNotEmpty()) {
-                    binding.tvNickname28.setTextColor(getColor(R.color.error))
-                    binding.tvNickname28.text = getString(R.string.set_nickname_2_8)
-                    binding.etChNickname.setBackgroundResource(R.drawable.shape_text_field_small_red)
-                } else {
-                    binding.tvNickname28.setTextColor(getColor(R.color.gray600))
-                }
-
-                userInfoViewModel.updateNickname(inputNickname)
+            if (!isValidLength && inputNickname.isNotEmpty()) {
+                binding.tvNickname28.setTextColor(getColor(R.color.error))
+                binding.tvNickname28.text = getString(R.string.set_nickname_2_8)
+                binding.etChNickname.setBackgroundResource(R.drawable.shape_text_field_small_red)
+            } else {
+                binding.tvNickname28.setTextColor(getColor(R.color.gray600))
             }
+        }
 
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
-            override fun afterTextChanged(p0: Editable?) {}
-        })
-
-        setOnCheckNicknameClickListener()
+        setOnCheckNicknameDuplicationClickListener()
         setCollegeDepartmentClickListener()
         collectButtonEnableState()
         collectUIState()
@@ -97,8 +93,8 @@ class UserInfoActivity :
         }
     }
 
-    private fun setOnCheckNicknameClickListener() {
-        binding.btnCheckNickname.setOnClickListener {
+    private fun setOnCheckNicknameDuplicationClickListener() {
+        binding.btnCheckNicknameDuplication.setOnClickListener {
             userInfoViewModel.checkNickname(inputNickname)
 
             // 닉네임 중복 확인 후 UI 상태 업데이트 로직
@@ -108,7 +104,7 @@ class UserInfoActivity :
             lifecycleScope.launch {
                 userInfoViewModel.uiState.collectLatest {
                     if (it.isEnableName) {
-                        binding.btnCheckNickname.isEnabled = false // 중복확인 비활성화
+                        binding.btnCheckNicknameDuplication.isEnabled = false // 중복확인 비활성화
                         binding.btnComplete.isEnabled = true // 저장하기 활성화
                         binding.tvNickname28.text = getString(R.string.set_nickname_able)
                         binding.etChNickname.setBackgroundResource(R.drawable.shape_text_field_small)

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -47,13 +47,13 @@ class UserInfoActivity :
         binding.btnComplete.isEnabled = false
 
         lifecycleScope.launch {
-            userInfoViewModel.uiState.collectLatest { state ->
-                if (binding.etChNickname.text.toString() != state.nickname) {
-                    binding.etChNickname.setText(state.nickname)
-                    binding.etChNickname.setSelection(state.nickname.length) // 커서 끝으로 이동
+            userInfoViewModel.uiState.collectLatest { it ->
+                if (binding.etChNickname.text.toString() != it.nickname) {
+                    binding.etChNickname.setText(it.nickname)
+                    binding.etChNickname.setSelection(it.nickname.length) // 커서 끝으로 이동
                 }
-                binding.tvCollege.text = state.selectedCollege.collegeName
-                binding.tvDepartment.text = state.selectedDepartment.departmentName
+                binding.tvCollege.text = it.selectedCollege.collegeName
+                binding.tvDepartment.text = it.selectedDepartment.departmentName
             }
         }
 

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -10,7 +10,6 @@ import android.view.WindowManager
 import android.widget.PopupWindow
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
-import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoViewModel.kt
@@ -63,7 +63,7 @@ class UserInfoViewModel @Inject constructor(
     fun checkNickname(inputNickname: String) {
         viewModelScope.launch {
             validateUserNameUseCase(inputNickname).onStart {
-                _uiState.update { it.copy(loading = true) }
+                _uiState.update { it.copy(loading = true, nickname = inputNickname) }
             }.onCompletion {
                 _uiState.update { it.copy(loading = false) }
             }.catch { e ->
@@ -76,7 +76,6 @@ class UserInfoViewModel @Inject constructor(
                             isEnableName = true,
                             toastMessage = "사용가능한 닉네임 입니다.",
                             isNicknameChecked = true,
-                            nickname = inputNickname,
                         )
                     }
                 } else {
@@ -84,7 +83,6 @@ class UserInfoViewModel @Inject constructor(
                         it.copy(
                             isEnableName = false,
                             toastMessage = "이미 사용 중인 닉네임 입니다.",
-                            nickname = inputNickname,
                         )
                     }
                 }

--- a/app/src/main/res/layout/activity_user_info.xml
+++ b/app/src/main/res/layout/activity_user_info.xml
@@ -46,7 +46,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tv_ch_nickname" />
 
         <Button
-            android:id="@+id/btn_check_nickname"
+            android:id="@+id/btn_check_nickname_duplication"
             style="@style/Button2"
             android:layout_width="wrap_content"
             android:layout_height="52dp"


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->

내정보 수정 > EditText 입력 오류 수정

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- addTextChangedListener에서도 userInfoViewModel.updateNickname(inputNickname)을 호출하던 문제 + Flow collect에서 무조건 setText 호출 → TextWatcher 재호출 → 입력 루프 꼬임이 원인 이었음
- 값이 바뀌었을 때만 setText + 커서 위치를 setSelection으로 보정으로 문제 해결했습니다
- 중간에 닉네임을 수정 후에 중복 확인 버튼을 클릭 시 기존 내 닉네임이 잠깐 노출되는 문제가 있었는데요, 닉네임 중복확인 호출하자마자 nickname을 입력한 닉네임으로 바로 업데이트 하도록 수정해서 해결했습니다.


https://github.com/user-attachments/assets/7e75a287-0a16-4559-a624-7e0a441ff218



## Issue

- Resolves #355 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

커밋 내역 중에 afterTextChanged 관련 로직이 잠깐 있는데, afterTextChanged 로 수정하려다가 현 로직은 onTextChanged 가 필요해 롤백 했습니다 ㅎㅎ,, 

닉네임 수정 후 이전 화면인 마이페이지로 진입 시 바뀐 닉네임으로 바로 보이도록 수정해야합니다 -> 바로 작업할게요
