### PR TITLE
[Fix] FCM과 로컬 알림의 Launch Path 분리

### DIFF
--- a/app/src/main/java/com/eatssu/android/alarm/EatSsuFirebaseMessagingService.kt
+++ b/app/src/main/java/com/eatssu/android/alarm/EatSsuFirebaseMessagingService.kt
@@ -45,7 +45,7 @@ class EatSsuFirebaseMessagingService : FirebaseMessagingService() {
         notificationManager.createNotificationChannel(channel)
 
         val intent = Intent(this, IntroActivity::class.java).apply {
-            putExtra("launch_path", "notification")
+            putExtra("launch_path", "remote_notification")
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
 

--- a/app/src/main/java/com/eatssu/android/alarm/NotificationReceiver.kt
+++ b/app/src/main/java/com/eatssu/android/alarm/NotificationReceiver.kt
@@ -46,7 +46,7 @@ class NotificationReceiver : BroadcastReceiver() {
         val pendingIntent = PendingIntent.getActivity(
             context,
             0,
-            intent.putExtra("launch_path", "notification"),
+            intent.putExtra("launch_path", "local_notification"),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroActivity.kt
@@ -63,7 +63,8 @@ class IntroActivity : AppCompatActivity() {
         val launchPath = intent.getStringExtra("launch_path")
         when (launchPath) {
             "widget" -> EventLogger.appLaunch(LaunchPath.WIDGET)
-            "notification" -> EventLogger.appLaunch(LaunchPath.LOCAL_NOTIFICATION)
+            "local_notification" -> EventLogger.appLaunch(LaunchPath.LOCAL_NOTIFICATION)
+            "remote_notification" -> EventLogger.appLaunch(LaunchPath.REMOTE_NOTIFICATION)
             // launch_path가 없으면 일반적인 앱 아이콘 클릭으로 간주
             else -> EventLogger.appLaunch(LaunchPath.ICON)
         }

--- a/core/common/src/main/java/com/eatssu/common/enums/LaunchPath.kt
+++ b/core/common/src/main/java/com/eatssu/common/enums/LaunchPath.kt
@@ -3,5 +3,6 @@ package com.eatssu.common.enums
 enum class LaunchPath(val value: String) {
     ICON("icon"),
     LOCAL_NOTIFICATION("local_notification"),
+    REMOTE_NOTIFICATION("remote_notification"),
     WIDGET("widget"),
 }


### PR DESCRIPTION
## Summary
시간 상의 이유로 진행하지 못했던 launch_path 구분 추가
local_notification과 remote_notification으로 분리했습니다.

## To reviewers
