### PR TITLE
[Fix] 500대 네트워크 오류 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,6 +130,9 @@
             android:name=".presentation.mypage.terms.WebViewActivity"
             android:exported="false" />
         <activity
+                android:name=".presentation.error.ErrorActivity"
+                android:exported="false" />
+        <activity
             android:name=".presentation.login.IntroActivity"
             android:exported="true">
             <!-- 기본 런처 필터 -->

--- a/app/src/main/java/com/eatssu/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/eatssu/android/di/NetworkModule.kt
@@ -1,8 +1,10 @@
 package com.eatssu.android.di
 
 
+import android.content.Context
 import com.eatssu.android.BuildConfig
 import com.eatssu.android.BuildConfig.BASE_URL
+import com.eatssu.android.di.network.NetworkErrorInterceptor
 import com.eatssu.android.di.network.TokenAuthenticator
 import com.eatssu.android.di.network.TokenInterceptor
 import com.eatssu.android.domain.usecase.auth.GetRefreshTokenUseCase
@@ -13,6 +15,7 @@ import com.eatssu.android.domain.usecase.auth.SetRefreshTokenUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
@@ -55,12 +58,14 @@ object NetworkModule {
     @Provides
     fun provideAuthOkHttpClient(
         tokenInterceptor: TokenInterceptor,
-        tokenAuthenticator: TokenAuthenticator
+        tokenAuthenticator: TokenAuthenticator,
+        networkErrorInterceptor: NetworkErrorInterceptor
     ) = if (BuildConfig.DEBUG) {
         val loggingInterceptor = HttpLoggingInterceptor()
         loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
 
         OkHttpClient.Builder()
+            .addInterceptor(networkErrorInterceptor)
             .addInterceptor(loggingInterceptor)
             .addInterceptor(tokenInterceptor)
             .authenticator(tokenAuthenticator)
@@ -68,6 +73,7 @@ object NetworkModule {
     } else {
         // 프로덕션 환경에서는 로깅 인터셉터를 추가하지 않음
         OkHttpClient.Builder()
+            .addInterceptor(networkErrorInterceptor)
             .addInterceptor(tokenInterceptor)
             .authenticator(tokenAuthenticator)
             .build()
@@ -77,8 +83,11 @@ object NetworkModule {
     @Singleton
     @Provides
     @NoToken
-    fun provideNoAuthOkHttpClient(): OkHttpClient {
+    fun provideNoAuthOkHttpClient(
+        networkErrorInterceptor: NetworkErrorInterceptor
+    ): OkHttpClient {
         val builder = OkHttpClient.Builder()
+            .addInterceptor(networkErrorInterceptor)
         if (BuildConfig.DEBUG) {
             builder.addInterceptor(HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
@@ -106,6 +115,14 @@ object NetworkModule {
             .addConverterFactory(GsonConverterFactory.create())
             .addConverterFactory(NullOnEmptyConverterFactory())
             .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideNetworkErrorInterceptor(
+        @ApplicationContext context: Context
+    ): NetworkErrorInterceptor {
+        return NetworkErrorInterceptor(context)
     }
 
     @Provides

--- a/app/src/main/java/com/eatssu/android/di/network/NetworkErrorInterceptor.kt
+++ b/app/src/main/java/com/eatssu/android/di/network/NetworkErrorInterceptor.kt
@@ -1,0 +1,58 @@
+package com.eatssu.android.di.network
+
+import android.content.Context
+import android.content.Intent
+import com.eatssu.android.data.dto.response.BaseResponse
+import com.eatssu.android.presentation.error.ErrorActivity
+import com.google.gson.Gson
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.IOException
+import javax.inject.Inject
+
+
+/**
+ * 네트워크 오류를 처리하는 인터셉터
+ * IOException(SocketTimeoutException, UnknownHostException) 발생 시 AlertDialog를 띄우는 ErrorActivity로 이동
+ */
+class NetworkErrorInterceptor @Inject constructor(
+    private val context: Context,
+) : Interceptor {
+
+    companion object {
+        private val gson = Gson()
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        try {
+            return chain.proceed(request)
+        } catch (e: IOException) {
+            val intent = Intent(context, ErrorActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                putExtra("message", "서버 통신에 실패했습니다. 잠시 후 다시 시도해 주세요.")
+            }
+            context.startActivity(intent)
+
+            val baseResponse = BaseResponse<Void>(
+                isSuccess = false,
+                code = 500, // 서버 처리 오류인지 통신 불가인지 구분
+                message = "서버 통신 실패",
+            )
+            val json = gson.toJson(baseResponse)
+            val responseBody = json.toResponseBody("application/json".toMediaTypeOrNull())
+
+            return Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200) // HTTP 응답 코드는 200으로 해야 Retrofit에서 에러로 처리하지 않음
+                .message("서버 통신 실패")
+                .body(responseBody)
+                .build()
+        }
+    }
+}

--- a/app/src/main/java/com/eatssu/android/presentation/error/ErrorActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/error/ErrorActivity.kt
@@ -3,17 +3,15 @@ package com.eatssu.android.presentation.error
 import android.app.AlertDialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.eatssu.android.databinding.ActivityIntroBinding
+import com.eatssu.android.databinding.ActivityErrorBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ErrorActivity : AppCompatActivity() {
 
-    private lateinit var binding: ActivityIntroBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityIntroBinding.inflate(layoutInflater)
+        val binding = ActivityErrorBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         showDialog()

--- a/app/src/main/java/com/eatssu/android/presentation/error/ErrorActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/error/ErrorActivity.kt
@@ -1,0 +1,33 @@
+package com.eatssu.android.presentation.error
+
+import android.app.AlertDialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.eatssu.android.databinding.ActivityIntroBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ErrorActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityIntroBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityIntroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        showDialog()
+    }
+
+    private fun showDialog() {
+        val message = intent.getStringExtra("message") ?: "알 수 없는 문제가 발생했습니다. 잠시 후 다시 시도해 주세요."
+
+        AlertDialog.Builder(this)
+            .setTitle("알림")
+            .setMessage(message)
+            .setCancelable(false)
+            .setPositiveButton("확인") { _, _ -> finish() }
+            .setOnDismissListener { finish() }
+            .show()
+    }
+}

--- a/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/IntroViewModel.kt
@@ -59,7 +59,7 @@ class IntroViewModel @Inject constructor(
                 .collect {
                     if (it.result == true) { //토큰이 있고 유효함
                         _uiState.value = UiState.Success(IntroState.ValidToken)
-                    } else { //토큰이 있어도 유효하지 않음
+                    } else if (it.code != 500) { // 토큰이 있어도 유효하지 않음
                         _uiState.value = UiState.Error
                         _uiEvent.emit(UiEvent.ShowToast("로그인이 필요합니다"))
                     }

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/primary"
+        tools:context=".presentation.error.ErrorActivity">
+
+    <ImageView
+            android:layout_width="250dp"
+            android:layout_height="wrap_content"
+            android:scaleType="centerInside"
+            android:layout_margin="65dp"
+            android:src="@drawable/img_new_logo_white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
서버가 꺼지거나 응답할 수 없는 경우와 네트워크 연결이 아예 기기에서 안될 때 발생하던 UnknownHostException, SocketTimeoutException 대응 추가
okhttp3로 보내는 모든 서버 요청에서 IOException가 발생하면 AlertDialog를 띄우는 ErrorActivity로 이동합니다.

## Describe your changes
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/62950b09-2c40-430e-b2a4-1f41f723f84e" />


## Issue

- Resolves #371
- Resolves #295

## To reviewers
- Intro 에서만 서버 통신 오류 확인하지 않고 모든 네트워크 요청의 오류에 대응하도록 작성했습니다. 앱을 정상적으로 사용하고 있다가 서버가 죽었으면 그때도 오류 페이지로 넘어가야할 것 같더라구요!
- 다만 기존 IntroViewModel처럼 오류 발생 시 LoginActivity와 같이 새로운 Activity로 이동하는 경우, NetworkErrorInterceptor가 ErrorActivity로 이동시킨 이후에 새로운 Activity로 이동하게 됩니다.
- 그래서 새 ViewModel을 만들 떄 네트워크 요청 > 오류 발생 시 Activity 이동과 같은 흐름에서 문제가 없는지 검토해야 해요. 지금 코드에서는 문제 없습니다!
