### PR TITLE
Feat: 기기 네비게이션바와 앱 내 바텀네비바 겹침 문제 해결

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
@@ -84,25 +84,35 @@ abstract class BaseActivity<B : ViewBinding>(
         // refreshtoken 관리
         observeTokenExpiration()
 
-        setInset()
+        setContainerInset()
 
     }
 
-    private fun setInset() {
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.toolbar)) { view, insets ->
+    private fun setContainerInset() {
+        // Toolbar: topInset만 적용
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { view, insets ->
             val topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top
-            view.setPadding(0, topInset, 0, 24)
-            WindowInsetsCompat.CONSUMED
+            view.setPadding(
+                /* left = */ 0,
+                /* top = */ topInset,
+                /* right = */ 0,
+                /* bottom = */ 0
+            )
+            insets
         }
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.fl_content)) { view, insets ->
             val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
             view.setPadding(
-                systemInsets.left,
-                view.paddingTop,
-                systemInsets.right,
-                systemInsets.bottom
+                /* left = */ systemInsets.left,
+                /* top = */ 0,
+                /* right = */ systemInsets.right,
+                /* bottom = */ systemInsets.bottom
             )
+
+            // 소비된 인셋을 반환하여 자식 뷰가 다시 받지 않도록 함
             WindowInsetsCompat.CONSUMED
         }
     }

--- a/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewbinding.ViewBinding
 import com.eatssu.android.R
 import com.eatssu.android.data.repository.FirebaseRemoteConfigRepository
-import com.eatssu.android.presentation.common.AndroidMessageDialogActivity
 import com.eatssu.android.presentation.common.ForceUpdateDialogActivity
 import com.eatssu.android.presentation.common.NetworkConnection
 import com.eatssu.android.presentation.common.VersionViewModel
@@ -171,13 +170,6 @@ abstract class BaseActivity<B : ViewBinding>(
 
     private fun showForceUpdateDialog() {
         val intent = Intent(this, ForceUpdateDialogActivity::class.java)
-        startActivity(intent)
-    }
-
-    private fun showAndroidMessageDialog(message: String) {
-        val intent = Intent(this, AndroidMessageDialogActivity::class.java)
-        intent.putExtra("message",message)
-        Timber.d("BaseActivity", "공지사항: $message")
         startActivity(intent)
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:navGraph="@navigation/eatssu_navigation"/>

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray100"
     tools:context=".presentation.cafeteria.CafeteriaFragment">
 
     <!--  로고 및 상단 바  -->


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->

edge-to-edge 적용 후
Android 버전 9 (14이하)에서 기기 네비게이션바와 앱 내 바텀네비바 겹침 문제를 해결했습니다.

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

#### [Before]
<img width="270" height="600" alt="edge-to-edge(before)" src="https://github.com/user-attachments/assets/95d80d2b-c45f-4dc6-92ec-433ecb78a372" />


기존 캘린더뷰에서 gray100이 적용되어있어 마치 statusbar가 회색처럼 보여 해당 background color를 삭제했습니다
<img width="376" height="189" alt="Screenshot 2025-09-30 at 1 10 58 PM" src="https://github.com/user-attachments/assets/0c35633c-ff5d-4210-a5fe-e4e97ad74bbe" />


#### [After]

https://github.com/user-attachments/assets/956e0338-9e9b-4a27-aac5-060e49e60afc


## Issue

- Resolves #339 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->


우리 baseActivity에서 toolbar가 gone일 때, 아닐때를 동시에 쓰기 때문에
이를 고려해서 
topInset이랑 bottomInset을 별도의 컴포넌트에서 각각 부여하도록 했습니다.

[before]
그리고 기존 코드에서 문제가 일어났던 원인은 

```
// 소비된 인셋을 반환하여 자식 뷰가 다시 받지 않도록 함 
WindowInsetsCompat.CONSUMED
```
toolbar에 topInset 적용 후 해당 코드를 사용하면서 
하위 뷰까지 inset이 전달되지 않아 BottomNavigationView에 bottomInset이 적용되지 않았던 것입니다.


[after]
그래서 Toolbar 에 inset을 적용 후에 
Toolbar와 Container 각각에서 필요한 inset만 분리 적용해서
Toolbar에서 inset을 소비하지 않고, Container가 bottomInset을 받을 수 있도록 수정했습니다.