### PR TITLE
[Fix] 최초 닉네임 설정시 발생하는 오류 해결

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -54,7 +54,7 @@ class UserInfoActivity :
             userInfoViewModel.uiState.collectLatest { it ->
                 if (binding.etChNickname.text.toString() != it.nickname) {
                     binding.etChNickname.setText(it.nickname)
-                    binding.etChNickname.setSelection(it.nickname.length) // 커서 끝으로 이동
+                    binding.etChNickname.setSelection(it.nickname.length.coerceAtMost(8)) // 커서 끝으로 이동
                 }
                 binding.tvCollege.text = it.selectedCollege.collegeName
                 binding.tvDepartment.text = it.selectedDepartment.departmentName

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -54,7 +54,7 @@ class UserInfoActivity :
             userInfoViewModel.uiState.collectLatest { it ->
                 if (binding.etChNickname.text.toString() != it.nickname) {
                     binding.etChNickname.setText(it.nickname)
-                    binding.etChNickname.setSelection(it.nickname.length.coerceAtMost(8)) // 커서 끝으로 이동
+                    binding.etChNickname.setSelection(binding.etChNickname.text.length) // 커서 끝으로 이동
                 }
                 binding.tvCollege.text = it.selectedCollege.collegeName
                 binding.tvDepartment.text = it.selectedDepartment.departmentName


### PR DESCRIPTION
## Summary
- 서버에서 최초 닉네임을 설정해줄 때 'user-XXXX' 9글자 닉네임을 지정해줍니다.
- UserInfoActivity의 닉네임 입력 칸의 maxLength가 8로 설정되어 있어, 'user-XXX' 8글자로 잘립니다.
- 그러나 현재 로직에서는 서버에서 받은 9글자 닉네임을 기준으로 마지막 글자에 커서를 두어서 IndexOutOfBoundsException가 발생합니다.
- 서버쪽에서도 해결해야 할 문제지만, 우선 서버에서 수신한 닉네임을 기준으로 커서를 이동시키게 수정했습니다.

## Describe your changes
<img width="375" height="54" alt="image" src="https://github.com/user-attachments/assets/738d2b18-d16f-4aac-9097-a5d70a4cc2a7" />


`binding.etChNickname.setText(it.nickname)` 이전 이후를 로깅해보았는데, maxLength로 인해 user-251까지만 넣어지는 것을 확인했습니다.
이전에는 앱을 키면 무조건 닉네임을 설정해주세요 라는 토스트와 함께 크래시가 발생했습니다.

https://console.firebase.google.com/u/0/project/eat-ssu-2023/crashlytics/app/android:com.eatssu.android/issues/e9b00d61b337c9f23b655b09f8a7a8c6?time=7d&types=crash&sessionEventKey=68E0B91A010500014FC2F75EBC31E3FE_2135689816230416376


## Issue

- Resolves #387

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

