### PR TITLE
[Refactor] IntroActivity의 Race Condition 구조 리팩토링

### DIFF
--- a/app/src/main/java/com/eatssu/android/domain/usecase/health/HealthCheckUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/health/HealthCheckUseCase.kt
@@ -3,6 +3,10 @@ package com.eatssu.android.domain.usecase.health
 import com.eatssu.android.domain.repository.HealthCheckRepository
 import javax.inject.Inject
 
+/**
+* 서버와 정상적으로 통신할 수 있는지 확인합니다.
+* 실제 서버의 상태(healthy)를 체크하는 목적이 아니라, 네트워크 연결이 가능한지 확인하는 용도입니다.
+*/
 class HealthCheckUseCase @Inject constructor(
     private val healthCheckRepository: HealthCheckRepository
 ) {

--- a/app/src/main/java/com/eatssu/android/presentation/intro/IntroActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/intro/IntroActivity.kt
@@ -9,8 +9,8 @@ import com.eatssu.android.databinding.ActivityIntroBinding
 import com.eatssu.android.presentation.MainActivity
 import com.eatssu.android.presentation.UiEvent
 import com.eatssu.android.presentation.UiState
+import com.eatssu.android.presentation.error.ServerErrorActivity
 import com.eatssu.android.presentation.login.LoginActivity
-import com.eatssu.android.presentation.util.observeNetworkError
 import com.eatssu.android.presentation.util.showToast
 import com.eatssu.android.presentation.util.startActivity
 import com.eatssu.common.EventLogger
@@ -42,8 +42,17 @@ class IntroActivity : AppCompatActivity() {
             introViewModel.uiState.collectLatest { state ->
                 when (state) {
                     is UiState.Success -> {
-                        startActivity<MainActivity>()
-                        finish()
+                        when (state.data) {
+                            IntroState.ValidToken -> {
+                                startActivity<MainActivity>()
+                                finish()
+                            }
+
+                            IntroState.ServerError -> {
+                                startActivity<ServerErrorActivity>()
+                                finish()
+                            }
+                        }
                     }
 
                     is UiState.Error -> {
@@ -68,8 +77,6 @@ class IntroActivity : AppCompatActivity() {
                 }
             }
         }
-
-        observeNetworkError()
     }
 
     private fun log() {

--- a/app/src/main/java/com/eatssu/android/presentation/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/intro/IntroViewModel.kt
@@ -39,7 +39,7 @@ class IntroViewModel @Inject constructor(
 
             // 서버와 통신 가능한지 먼저 확인
             if (!healthCheckUseCase()) {
-                // 아무 State 처리 없이 Return해도 NetworkErrorEventBus로 인해 오류 페이지로 이동
+                _uiState.value = UiState.Success(IntroState.ServerError)
                 return@launch
             }
 
@@ -64,6 +64,7 @@ class IntroViewModel @Inject constructor(
     }
 }
 
-sealed class IntroState {
-    object ValidToken : IntroState()
+sealed interface IntroState {
+    data object ValidToken : IntroState
+    data object ServerError : IntroState
 }


### PR DESCRIPTION
## Summary
ApiResultCall에서 소켓 오류, DNS 등 네트워크 오류가 발생했을 때 NetworkErrorEventBus로 이 문제를 알려줍니다.

IntroActivity가 이 NetworkErrorEventBus에 구독해 문제가 발생하면 ServerErrorActivity로 넘어갑니다.

근데 IntroViewModel의 기존 흐름인 autoLogin() 에서 명시적인 health check 결과 검증 후 흐름을 끊지 않으면 getAccessTokenUseCase()가 empty를 반환해서 LoginActivity로 넘어갑니다.

ServerErrorActivity로 갔는데도 LoginActivity가 더 늦게 이동되어서 로그인 창이 뜨는걸 방지하려고 작성했던 기존 코드를 개선합니다.

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

## Issue
- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

