### PR TITLE
[Hotfix] 사진 있는 리뷰 작성시 uistate Success에 대한 race condition 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/write/ReviewWriteViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/write/ReviewWriteViewModel.kt
@@ -55,7 +55,7 @@ class UploadReviewViewModel @Inject constructor(
             return null
         }
 
-        _uiState.value = UiState.Success(Unit)
+        // Success에 대한 정의는 한 곳에서만 관리
         return url
     }
 }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->

2025.11.24 3.1.6(44) QA 담당자 이윤소
https://eat-ssu.slack.com/archives/C07N4U8FN65/p1763979235471709?thread_ts=1763889538.781759&cid=C07N4U8FN65

### 문제 상황 정의 
> 순서가 리뷰 씀 > 네트웤 오류 다이알로그 뜸> 근데 리뷰 작성은 성공함

### 문제 파악
- postReview와 saveS3 둘다 UIState를 Success로 바꾸기 때문에
- Acitivity에서 postReview 작업이 다 안끝난 상태에서 Success 인식 -> finish 호출로 인해 viewmodelscope가 깨져 IOException으로 인식 -> observeNetworkError 호출되어 
<img width="3024" height="4032" alt="image" src="https://github.com/user-attachments/assets/40078e84-caf5-43e8-802f-1d6bc930c1af" />

## Describe your changes
| 수정 전 | 수정 후|
|--|--|
|<img width="673" height="640" alt="스크린샷 2025-11-24 오후 8 21 26" src="https://github.com/user-attachments/assets/0dec446f-0179-4cfa-90bf-0c0cb6f8256e" />|<img width="759" height="684" alt="스크린샷 2025-11-24 오후 8 21 43" src="https://github.com/user-attachments/assets/4617dce4-dae6-4a27-ae03-027972dcda5b" />|
