### PR TITLE
[Hotfix] Release에서 발생하던 문제 해결 및 3.1.8 릴리즈

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 45
-        versionName = "3.1.7"
+        versionCode = 46
+        versionName = "3.1.8"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,10 +27,7 @@
 # https://firebase.google.com/docs/database/android/start?hl=ko
 -keepattributes Signature
 
--keep class com.eatssu.android.data.dto.** {
-  *;
-}
--keep class com.eatssu.android.data.enums.** {
+-keep class com.eatssu.android.data.remote.dto.** {
   *;
 }
 -keep class com.eatssu.android.data.model.** {

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.eatssu.common.enums.Restaurant
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import javax.inject.Inject

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
@@ -60,8 +60,7 @@ class FirebaseRemoteConfigRepositoryImpl @Inject constructor(
     private fun parseCafeteriaJson(json: String): List<RestaurantInfo> {
         return try {
             val gson = Gson()
-            val listType = object : TypeToken<List<RestaurantInfo>>() {}.type
-            val dtoList: List<RestaurantInfo> = gson.fromJson(json, listType)
+            val dtoList = gson.fromJson(json, Array<RestaurantInfo>::class.java)
 
             dtoList.map { dto ->
                 RestaurantInfo(

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/FirebaseRemoteConfigRepositoryImpl.kt
@@ -59,7 +59,7 @@ class FirebaseRemoteConfigRepositoryImpl @Inject constructor(
     private fun parseCafeteriaJson(json: String): List<RestaurantInfo> {
         return try {
             val gson = Gson()
-            val dtoList = gson.fromJson(json, Array<RestaurantInfo>::class.java)
+            val dtoList = gson.fromJson(json, Array<RestaurantInfo>::class.java) ?: emptyArray()
 
             dtoList.map { dto ->
                 RestaurantInfo(


### PR DESCRIPTION
## Summary
https://eat-ssu.slack.com/archives/C0517NBULDR/p1764037363649059

- [Refactor] SharedPreference에서 datastore로 마이그레이션  ([#396](https://github.com/EAT-SSU/Android/pull/396))
- [Refactor] firebase remote config 활용 코드 개선 ([#398](https://github.com/EAT-SSU/Android/pull/398))

에서 문제가 발생했습니다. 정확한 이유는 다음과 같습니다.

- dto 관련 파일들이 com.eatssu.android.data.dto에서 com.eatssu.android.data.remote.dto로 이동했는데, proguard-rules.pro에는 여전히 -keep class com.eatssu.android.data.dto.**  를 유지시켰음
- FirebaseRemoteConfigRepositoryImpl#parseCafeteriaJson 에서 기존 org.json.JSONArray 파싱 방식에서 Gson의 TypeToken을 사용하는 방식으로 변경했는데, Proguard가 TypeToken에 대한 제네릭스 정보를 strip해서 다음 오류 발생

```
Failed to parse cafeteria JSON
java.lang.IllegalStateException: TypeToken must be created with a type argument: new TypeToken<...>() {}; When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.
```

## Describe your changes
Proguard Rule를 수정하고, Gson 사용 시 TypeToken이 아니라 Java Class를 사용하게 해 해결했습니다.
급히 3.1.8을 배포해야했으므로 3.1.8(48) 버전업 후 배포까지 이 브랜치에서 한번에 진행했습니다.

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

