### PR TITLE
[Fix] review v2 UI 수정사항 반영

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListScreen.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListScreen.kt
@@ -354,10 +354,12 @@ fun ReviewInfoContent(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Row {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Icon(
                         painter = painterResource(R.drawable.ic_cafeteria_menu_selected),
-                        modifier = Modifier.size(24.dp),
+                        modifier = Modifier.size(18.dp),
                         tint = Primary,
                         contentDescription = "map restaurant icon"
                     )

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/component/ReviewItem.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/component/ReviewItem.kt
@@ -1,20 +1,24 @@
 package com.eatssu.android.presentation.cafeteria.review.list.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -74,24 +78,33 @@ fun ReviewItem(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.End
             ) {
-                IconButton(
-                    onClick = { onMoreClick() }
+                Box(
+                    modifier = Modifier
+                        .padding(18.dp) // 터치 영역 확장 ( (48 - 12) / 2 )
+                        .offset(x = 18.dp, y = 18.dp) // ← 시각 위치 되돌리기
+                        .clickable(
+                            onClick = onMoreClick,
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        )
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_menu_12),
                         contentDescription = "etc",
                         modifier = Modifier.size(12.dp),
-                        tint = Color.Unspecified,
+                        tint = Color.Unspecified
                     )
                 }
 
+                Spacer(modifier = Modifier.height(8.dp))
+
                 Text(
-                    writeDate,
+                    text = writeDate,
                     style = EatssuTheme.typography.caption3,
-                    color = Gray400,
-                    modifier = Modifier.padding(end = 20.dp) //20인 이유는 없음 IconButton에 넣으면서 padding 생겨서 끝점을 맞추려고 조절한 것임
+                    color = Gray400
                 )
             }
+
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/component/ReviewItem.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/component/ReviewItem.kt
@@ -1,20 +1,24 @@
 package com.eatssu.android.presentation.cafeteria.review.list.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -74,24 +78,33 @@ fun ReviewItem(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.End
             ) {
-                IconButton(
-                    onClick = { onMoreClick() }
+                Box(
+                    modifier = Modifier
+                        .padding(18.dp) // 터치 영역 확장 ( (48 - 12) / 2 )
+                        .offset(x = 18.dp, y = 18.dp) // 시각 위치 되돌리기
+                        .clickable(
+                            onClick = onMoreClick,
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        )
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_menu_12),
                         contentDescription = "etc",
                         modifier = Modifier.size(12.dp),
-                        tint = Color.Unspecified,
+                        tint = Color.Unspecified
                     )
                 }
 
+                Spacer(modifier = Modifier.height(8.dp))
+
                 Text(
-                    writeDate,
+                    text = writeDate,
                     style = EatssuTheme.typography.caption3,
-                    color = Gray400,
-                    modifier = Modifier.padding(end = 20.dp) //20인 이유는 없음 IconButton에 넣으면서 padding 생겨서 끝점을 맞추려고 조절한 것임
+                    color = Gray400
                 )
             }
+
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/core/design-system/src/main/java/com/eatssu/design_system/component/Chip.kt
+++ b/core/design-system/src/main/java/com/eatssu/design_system/component/Chip.kt
@@ -47,7 +47,7 @@ fun Chip(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_thumb_up),
                     contentDescription = "thumb up Image",
-                    modifier = Modifier.size(16.dp),
+                    modifier = Modifier.size(12.dp),
                     tint = Primary
                 )
                 Spacer(modifier = Modifier.width(4.dp))


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
리뷰 v2 ui 수정사항을 적용합니다
https://eat-ssu.slack.com/archives/C0517NBULDR/p1764935384836719

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

1. "오늘의메뉴" 옆 아이콘 좋아요칩의 좋아요 아이콘이 큰 것 같습니다 (제 기기 문제일수도....?)
2. 메뉴칩에서 좋아요칩과 그냥 칩의 크기가 다르게 보입니다!! 아이콘 문제일수도....

|전|후|
|--|--|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/475b86f2-0839-4b19-931c-d9dc4534f263" />|<img width="300" alt="스크린샷 2025-12-21 오후 3 48 22" src="https://github.com/user-attachments/assets/92f4a9cc-895c-4207-bd0d-b107a69b66ce" />|


3. 메뉴 화면 하단, 내 리뷰에서 리뷰 리스트가 왼쪽으로 정렬되어 있는 건지 오른쪽에 공백이 있습니다!!

|전|후|
|--|--|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/13482e16-3f4f-4464-91bc-e36b625129a8" />|<img width="300" alt="스크린샷 2025-12-21 오후 3 45 07" src="https://github.com/user-attachments/assets/c06ba55f-c2c4-4131-b466-41783c5e86f4" />|
