### PR TITLE
[Fix] NetworkCallback의 onAvailable, onLost가 메인 스레드에서 실행되지 않아 발생하던 문제 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/base/BaseActivity.kt
@@ -42,7 +42,7 @@ abstract class BaseActivity<B : ViewBinding>(
 
 
     private val networkCheck: NetworkConnection by lazy {
-        NetworkConnection(this)
+        NetworkConnection(this, lifecycleScope)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/eatssu/android/presentation/common/NetworkConnection.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/common/NetworkConnection.kt
@@ -7,6 +7,8 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 import com.eatssu.android.presentation.util.showDialog
 
@@ -20,6 +22,9 @@ class NetworkConnection(private val context: Context) :
         .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR) // 데이터 사용 관련 감지
         .addTransportType(NetworkCapabilities.TRANSPORT_WIFI) // 와이파이 사용 관련 감지
         .build()
+
+    // NetworkCallback은 백그라운드 스레드에서 호출되므로 Dialog 등 UI 작업은 메인 스레드에서 실행해야 함
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     // 네트워크 연결 안 되어있을 때 보여줄 다이얼로그
     private val dialog: Dialog by lazy {
@@ -59,18 +64,23 @@ class NetworkConnection(private val context: Context) :
     override fun onAvailable(network: Network) {
         super.onAvailable(network)
 
-        if (getConnectivityStatus() == null) {
-            // 네트워크 연결 안 되어 있을 때
-            dialog.show()
-        } else {
-            // 네트워크 연결 되어 있을 때
-            dialog.dismiss()
+        mainHandler.post {
+            if (getConnectivityStatus() == null) {
+                // 네트워크 연결 안 되어 있을 때
+                dialog.show()
+            } else {
+                // 네트워크 연결 되어 있을 때
+                dialog.dismiss()
+            }
         }
     }
 
     // 네트워크 끊겼을 때 실행되는 메소드
     override fun onLost(network: Network) {
         super.onLost(network)
-        dialog.show()
+
+        mainHandler.post {
+            dialog.show()
+        }
     }
 }

--- a/app/src/main/java/com/eatssu/android/presentation/common/NetworkConnection.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/common/NetworkConnection.kt
@@ -7,14 +7,16 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.os.Handler
-import android.os.Looper
 import android.provider.Settings
+import androidx.lifecycle.LifecycleCoroutineScope
+import kotlinx.coroutines.launch
 import com.eatssu.android.presentation.util.showDialog
 
 // 네트워크 연결 확인을 위해 네트워크 변경 시 알람에 사용하는 클래스 NetworkCallback 을 커스터마이징
-class NetworkConnection(private val context: Context) :
-    ConnectivityManager.NetworkCallback() {
+class NetworkConnection(
+    private val context: Context,
+    private val lifecycleScope: LifecycleCoroutineScope
+) : ConnectivityManager.NetworkCallback() {
 
     private val connectivityManager: ConnectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -22,9 +24,6 @@ class NetworkConnection(private val context: Context) :
         .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR) // 데이터 사용 관련 감지
         .addTransportType(NetworkCapabilities.TRANSPORT_WIFI) // 와이파이 사용 관련 감지
         .build()
-
-    // NetworkCallback은 백그라운드 스레드에서 호출되므로 Dialog 등 UI 작업은 메인 스레드에서 실행해야 함
-    private val mainHandler = Handler(Looper.getMainLooper())
 
     // 네트워크 연결 안 되어있을 때 보여줄 다이얼로그
     private val dialog: Dialog by lazy {
@@ -64,7 +63,7 @@ class NetworkConnection(private val context: Context) :
     override fun onAvailable(network: Network) {
         super.onAvailable(network)
 
-        mainHandler.post {
+        lifecycleScope.launch {
             if (getConnectivityStatus() == null) {
                 // 네트워크 연결 안 되어 있을 때
                 dialog.show()
@@ -79,8 +78,12 @@ class NetworkConnection(private val context: Context) :
     override fun onLost(network: Network) {
         super.onLost(network)
 
-        mainHandler.post {
-            dialog.show()
+        // Wi-Fi와 모바일 데이터가 모두 연결된 상태에서 Wi-Fi만 끊겨도 onLost가 호출될 수 있으므로,
+        // 현재 활성화 네트워크 여부 검증 필요
+        if (getConnectivityStatus() == null) {
+            lifecycleScope.launch {
+                dialog.show()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
https://console.firebase.google.com/project/eat-ssu-2023/crashlytics/app/android:com.eatssu.android/issues/406ced3d9ea75192abd7237fa65b2664?time=last-seven-days

ConnectivityManager.NetworkCallback의 콜백 함수들이 메인 스레드가 아닌 네트워크 연결 스레드에서 실행되어 발생하던 Dialog UI 처리 관련 문제 해결

<img width="881" height="97" alt="image" src="https://github.com/user-attachments/assets/bee7c2de-67f3-4240-8f10-87399ad723ea" />

[https://developer.android.com/develop/connectivity/network-ops/reading-network-state?hl=ko](https://developer.android.com/develop/connectivity/network-ops/reading-network-state?hl=ko)


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

