### PR TITLE
[Fix] 중복된 닉네임의 오류 메세지 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
@@ -33,7 +33,7 @@ class UserRepositoryImpl @Inject constructor(
                     Result.success(Unit)
                 } else {
                     Result.failure(
-                        Exception("올바르지 않은 닉네임이에요.")
+                        Exception("이미 사용 중인 닉네임이에요.")
                     )
                 }
             }


### PR DESCRIPTION
## Summary
이제 숭숭숭숭퍼노바 등의 존재하는 닉네임을 사용하려고 했을 때 기존의 '올바르지 않은 닉네임이에요' 가 아니라 정확하게 '이미 사용 중인 닉네임이에요.' 라고 표기해줍니다

## Describe your changes
<img width="1080" height="2400" alt="Screenshot_20251231_155148" src="https://github.com/user-attachments/assets/1d32d8be-6aec-466b-b3ad-58f393d57a20" />

## Issue

- Resolves #444

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

