### PR TITLE
[Feat] 문의하기 클릭 시 kakao channel로 연결 코드 SDK 코드로 수정 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,8 +189,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
-    // Kakao login SDK
+    // Kakao SDK
     implementation(libs.kakao.login)
+    implementation(libs.kakao.talk)
 
     // Hilt for Dependency Injection
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
@@ -26,10 +26,13 @@ import com.eatssu.android.presentation.mypage.myreview.MyReviewListComposeActivi
 import com.eatssu.android.presentation.mypage.terms.WebViewActivity
 import com.eatssu.android.presentation.mypage.userinfo.UserInfoActivity
 import com.eatssu.android.presentation.util.showToast
+import com.eatssu.common.EventLogger
 import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.enums.ScreenId
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import com.kakao.sdk.common.util.KakaoCustomTabsClient
+import com.kakao.sdk.talk.TalkApiClient
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -138,11 +141,15 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
         }
 
         binding.llInquire.setOnClickListener {
-            startWebView(
-                getString(R.string.kakao_talk_channel_url),
-                getString(R.string.contact),
-                ScreenId.EXTERNAL_INQUIRE
-            )
+            val context = requireContext()
+            val channelPublicId = "_ZlVAn"
+
+            TalkApiClient.instance.chatChannel(context, channelPublicId) {
+                val url = TalkApiClient.instance.chatChannelUrl(channelPublicId)
+                KakaoCustomTabsClient.openWithDefault(context, url)
+            }
+
+            EventLogger.screenView(ScreenId.EXTERNAL_INQUIRE)
         }
 
         binding.llMyReview.setOnClickListener {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,8 @@ glide = "4.15.1"
 glide-compiler = "4.12.0"
 compressor = "3.0.1"
 coroutines = "1.7.3"
-kakao-login = "2.8.6"
+kakao-login = "2.23.0"
+kakao-talk = "2.23.0"
 hilt = "2.50"
 androidxHilt = "1.2.0"
 play-services-base = "18.0.1"
@@ -148,6 +149,7 @@ transport-runtime = { group = "com.google.android.datatransport", name = "transp
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 compressor = { group = "id.zelory", name = "compressor", version.ref = "compressor" }
 kakao-login = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-login" }
+kakao-talk = { group = "com.kakao.sdk", name = "v2-talk", version.ref = "kakao-talk" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "ossLicenses" }
 oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "ossLicensesPlugin" }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
기존 웹뷰 이동 방식에서 
카카오 SDK를 통해
카카오톡 채널로 이동하는 공식 플로우를 사용하는 방식으로 수정 


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- WebView → SDK 기반 외부 연동
- 클릭 시 웹 카카오톡 채널이 아닌 카카오톡 앱 내 채널화면이 열림 
## Issue

- Resolves #407 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->
제훈님이 올려주신 코드에서 추가작업이 필요한줄 알았는데, 지금 확인해보니 카카오앱 내 채널 화면으로 이동되도록 코드 잘 작성해주신 것 같아 바로 PR 올립니다.
다만 제훈님과 저는 안드로이드 기기로 카카오톡 앱 로그인이 불가능하여서 갤럭시 유저(진님)이 해당 브랜치에서 테스트를 해주셔야 할 것 같습니다 ㅜㅜ @HI-JIN2 진
만약 정상작동 테스트되면 머지하면 좋을 것 같습니다

val channelPublicId = "_ZlVAn"

여기서 채널 id는 우리 채널 웹 링크의 마지막 부분과 같아 해당 링크 정상 접속되고 있습니다 http://pf.kakao.com/_ZlVAn
