### PR TITLE
[Feat] firebase app distribution CI 오류 수정 및 방식 수정 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
       github.event_name == 'push' ||
       (
         github.event_name == 'pull_request' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       )
     runs-on: ubuntu-latest
 
@@ -73,21 +73,21 @@ jobs:
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       run: ./gradlew assembleDebug
 
     - name: Assemble Release APK
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       run: ./gradlew assembleRelease
 
     - name: Upload Debug APK artifact
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       uses: actions/upload-artifact@v4
       with:
         name: debug-apk
@@ -97,7 +97,7 @@ jobs:
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       uses: actions/upload-artifact@v4
       with:
         name: release-apk
@@ -107,7 +107,7 @@ jobs:
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       run: |
         npm i -g firebase-tools
 
@@ -115,7 +115,7 @@ jobs:
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
@@ -130,7 +130,7 @@ jobs:
       if: >
         github.event_name == 'pull_request' &&
         github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'feat/')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,11 +16,7 @@ jobs:
   build:
     # develop push는 허용, develop으로의 PR 중 release/* 브랜치에서 온 PR만 허용
     if: >
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
-      )
+      github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     # develop push는 허용, develop으로의 PR 중 release/* 브랜치에서 온 PR만 허용
@@ -72,64 +76,44 @@ jobs:
     - name: Assemble Debug APK
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       run: ./gradlew assembleDebug
-
-    - name: Assemble Release APK
-      if: >
-        github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
-      run: ./gradlew assembleRelease
 
     - name: Upload Debug APK artifact
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       uses: actions/upload-artifact@v4
       with:
         name: debug-apk
         path: app/build/outputs/apk/debug/*.apk
 
+    - name: Assemble Release APK
+      if: >
+        github.event_name == 'pull_request' &&
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+      run: ./gradlew assembleRelease
+
     - name: Upload Release APK artifact
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       uses: actions/upload-artifact@v4
       with:
         name: release-apk
         path: app/build/outputs/apk/release/*.apk
 
+      # Release만 Firebase 배포
     - name: Install Firebase CLI
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
-      run: |
-        npm i -g firebase-tools
-
-    - name: Distribute Debug APK to Firebase App Distribution
-      if: >
-        github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-      env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-      run: |
-        firebase appdistribution:distribute app/build/outputs/apk/debug/*.apk \
-          --app "$FIREBASE_APP_ID" \
-          --groups "eat-ssu-android-qa" \
-          --release-notes "Debug | PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
-          --token "$FIREBASE_TOKEN"
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+      run: npm i -g firebase-tools
 
     - name: Distribute Release APK to Firebase App Distribution
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
@@ -139,3 +123,28 @@ jobs:
           --groups "eat-ssu-android-qa" \
           --release-notes "Release | PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
           --token "$FIREBASE_TOKEN"
+      
+
+      # Debug는 Artifact로만 공유 + PR 코멘트
+    - name: Comment PR with artifact download 안내
+      if: >
+        github.event_name == 'pull_request' &&
+        (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const body =
+            [
+              `✅ CI 완료`,
+              ``,
+              `- Debug APK: GitHub Actions Artifacts에서 다운로드 (run 링크: ${runUrl})`,
+              `- Release APK: Firebase App Distribution으로 배포됨 (그룹: eat-ssu-android-qa)`,
+            ].join('\n');
+          
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            body,
+          });

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,22 +70,39 @@ jobs:
       run: chmod +x gradlew
 
     - name: Assemble Debug APK
+      if: >
+        github.event_name == 'pull_request' &&
+        github.event.action == 'opened' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
       run: ./gradlew assembleDebug
 
     - name: Assemble Release APK
+      if: >
+        github.event_name == 'pull_request' &&
+        github.event.action == 'opened' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
       run: ./gradlew assembleRelease
 
     - name: Upload Debug APK artifact
+      if: >
+        github.event_name == 'pull_request' &&
+        github.event.action == 'opened' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
       uses: actions/upload-artifact@v4
       with:
         name: debug-apk
         path: app/build/outputs/apk/debug/*.apk
 
     - name: Upload Release APK artifact
+      if: >
+        github.event_name == 'pull_request' &&
+        github.event.action == 'opened' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
       uses: actions/upload-artifact@v4
       with:
         name: release-apk
         path: app/build/outputs/apk/release/*.apk
+
     - name: Install Firebase CLI
       if: >
         github.event_name == 'pull_request' &&

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
       github.event_name == 'push' ||
       (
         github.event_name == 'pull_request' &&
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        startsWith(github.event.pull_request.head.ref, 'release/')
       )
     runs-on: ubuntu-latest
 
@@ -76,12 +76,14 @@ jobs:
     - name: Assemble Debug APK
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       run: ./gradlew assembleDebug
 
     - name: Upload Debug APK artifact
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       uses: actions/upload-artifact@v4
       with:
@@ -91,12 +93,14 @@ jobs:
     - name: Assemble Release APK
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       run: ./gradlew assembleRelease
 
     - name: Upload Release APK artifact
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       uses: actions/upload-artifact@v4
       with:
@@ -107,12 +111,14 @@ jobs:
     - name: Install Firebase CLI
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       run: npm i -g firebase-tools
 
     - name: Distribute Release APK to Firebase App Distribution
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
@@ -129,6 +135,7 @@ jobs:
     - name: Comment PR with artifact download 안내
       if: >
         github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') && 
         (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
       uses: actions/github-script@v7
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,21 +72,21 @@ jobs:
     - name: Assemble Debug APK
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       run: ./gradlew assembleDebug
 
     - name: Assemble Release APK
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       run: ./gradlew assembleRelease
 
     - name: Upload Debug APK artifact
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       uses: actions/upload-artifact@v4
       with:
@@ -96,7 +96,7 @@ jobs:
     - name: Upload Release APK artifact
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       uses: actions/upload-artifact@v4
       with:
@@ -106,7 +106,7 @@ jobs:
     - name: Install Firebase CLI
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       run: |
         npm i -g firebase-tools
@@ -114,8 +114,7 @@ jobs:
     - name: Distribute Debug APK to Firebase App Distribution
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
-        startsWith(github.event.pull_request.head.ref, 'feat/')
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
@@ -129,7 +128,7 @@ jobs:
     - name: Distribute Release APK to Firebase App Distribution
       if: >
         github.event_name == 'pull_request' &&
-        github.event.action == 'opened' &&
+        github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'        startsWith(github.event.pull_request.head.ref, 'feat/')
         startsWith(github.event.pull_request.head.ref, 'feat/')
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- CI 오류 수정 
- release는 apk로 메일 전송, debug는 별도로 apk 추출하도록 변경 
- debug용 apk파일이 추출되면 아래처럼 봇이 해당 링크를 알려주고, 링크로 가면 apk를 다운받을 수 있습니다
- app distribution 관련 로직은 release/명을 가진 브랜치가 pr을 발행, commit 수정 등 이벤트를 발행할때마다 돌아요 (오래 걸립니다)

## Issue

- 관련 pr #425 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

이전 pr 병합 후 테스트를 해보니 오류가 나더라구요.. 알아보니까 우선 

Firebase App Distribution은 하나의 Firebase App = 하나의 패키지명(applicationId)을 기준으로 동작합니다
그런데 우리 프로젝트의 Debug APK는 com.eatssu.android.debug, Release APK는 com.eatssu.android 처럼 패키지명이 달라요

Firebase는 업로드되는 APK의 패키지명이 자신이 등록한 앱의 패키지명과 정확히 일치해야만 배포와 메일 발송을 해주는데.. 
그래서 하나의 Firebase App으로는 서로 다른 패키지명의 APK 두 개를 동시에 배포할 수 없는 것 같아요

Debug와 Release를 각각 메일로 보내려면 Firebase App 프로젝트를 2개 만들거나,
아니면 Debug APK의 패키지명을 Release와 같게 만들어야 하는데 이건 기존 로직을 해칠 수도 있을 것 같아서 우선 메일로는 release apk파일을 보내고, debug용 apk는 별도로 추출하는 형식으로 가야하지 않을까 싶습니다

사실 이렇게 되면 굳이 app distribution을 쓰는 의미가 있을까 싶긴해요
내부 안드팀끼리 논의하시고 굳이 필요없는 CI라고 생각되시면 관련 코드를 삭제하고 사용하셔도 될 것 같습니다

*현재 ci로는 메일로 정상 발송됨을 확인하긴 했습니다!