### PR TITLE
[Fix] notification 퍼미션 허용시에만 토스트 뜨도록 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 
 @AndroidEntryPoint
@@ -111,11 +113,16 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
         if (requestCode == 1000) {
+            val nowDatetime = LocalDateTime.now()
+            val formattedDate = nowDatetime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 // 권한이 승인됨
+                showInfoToast(getString(R.string.toast_notification_enable, formattedDate))
                 myPageViewModel.setNotificationOn()
             } else {
                 // 권한이 거부됨
+                showInfoToast(getString(R.string.toast_notification_disable, formattedDate))
                 myPageViewModel.setNotificationOff()
             }
         }

--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -110,17 +110,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-
         if (requestCode == 1000) {
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 // 권한이 승인됨
-                showInfoToast("EAT-SSU 알림 수신을 동의하였습니다.")
-                myPageViewModel.setNotificationOn() //바로 알림 받도록 설정
+                myPageViewModel.setNotificationOn()
             } else {
                 // 권한이 거부됨
-                showInfoToast("EAT-SSU 알림 수신을 거부하였습니다.\n$dateFormat")
-                myPageViewModel.setNotificationOff() //바로 알림 받도록 설정
+                myPageViewModel.setNotificationOff()
             }
         }
     }

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
@@ -63,6 +63,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
     override fun onResume() {
         super.onResume()
         myPageViewModel.fetchMyInfo() // 닉네임 변경 등으로부터 복귀 시 정보 갱신
+        checkNotificationPermissionChange() // 설정 화면에서 돌아왔을 때 권한 상태 확인
     }
 
     private fun setupObservers() {
@@ -105,6 +106,11 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
             binding.tvNickname.text = "닉네임을 설정해주세요"
         }
 
+        // 초기 권한 상태 저장 (처음 로드될 때만)
+        if (lastNotificationPermissionState == null) {
+            lastNotificationPermissionState = checkNotificationPermission(requireContext())
+        }
+
         // 알람 스위치 (리스너 잠시 해제 후 값 반영)
         binding.alarmSwitch.setOnCheckedChangeListener(null)
         binding.alarmSwitch.isChecked = state.isAlarmOn
@@ -114,13 +120,9 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
     }
 
     private fun handleAlarmSwitchChange(isChecked: Boolean) {
-        val nowDatetime = LocalDateTime.now()
-        val formattedDate = nowDatetime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
-
         if (isChecked) {
             if (checkNotificationPermission(requireContext())) {
                 myPageViewModel.setNotificationOn()
-                showInfoToast(getString(R.string.toast_notification_enable, formattedDate))
             } else {
                 showNotificationPermissionDialog()
                 // 권한 미허용이면 스위치 원복
@@ -132,7 +134,6 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
             }
         } else {
             myPageViewModel.setNotificationOff()
-            showInfoToast(getString(R.string.toast_notification_disable, formattedDate))
         }
     }
 
@@ -218,6 +219,28 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
                 android.Manifest.permission.POST_NOTIFICATIONS
             ) == PackageManager.PERMISSION_GRANTED
         } else true
+    }
+
+    private var lastNotificationPermissionState: Boolean? = null
+
+    private fun checkNotificationPermissionChange() {
+        val currentPermissionState = checkNotificationPermission(requireContext())
+        
+        // 이전 권한 상태가 저장되어 있고, 현재 상태와 다른 경우에만 토스트 표시
+        if (lastNotificationPermissionState != null && lastNotificationPermissionState != currentPermissionState) {
+            val nowDatetime = LocalDateTime.now()
+            val formattedDate = nowDatetime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+            
+            if (currentPermissionState) {
+                showInfoToast(getString(R.string.toast_notification_enable, formattedDate))
+                myPageViewModel.setNotificationOn()
+            } else {
+                showInfoToast(getString(R.string.toast_notification_disable, formattedDate))
+                myPageViewModel.setNotificationOff()
+            }
+        }
+        
+        lastNotificationPermissionState = currentPermissionState
     }
 
     private fun showLogoutDialog() {


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
>notification 퍼미션 허용/거부 시에만 토스트 뜨도록 수정합니다
>단순 알림 토글 on/off에는 토스트 X


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
[Screen_recording_20260303_194352.webm](https://github.com/user-attachments/assets/9dc67c43-f6aa-4b43-9157-ec0096b92423)

- 최초 접속시 노티피케이션 네이티브 퍼미션 동의 -> 토스트 (날짜 뜨면서 동의하셨습니다~)
- 최초 접속시 노티피케이션 네이티브 퍼미션 거부 -> 토스트 (날짜 뜨면서 거부하셨습니다~)
- 퍼미션 없을 때 마이페이지에서 토글 클릭해서 허용으로 바뀜 -> 토스트 (날짜 뜨면서 동의하셨습니다~)
- 퍼미션 있을 때 마이페이지에서 토글 클릭해서 허용으로 바뀜 -> 토스트 X
- 퍼미션 있을 때 마이페이지에서 토글 클릭해서 거부로 바뀜 -> 토스트 X

## Issue

- Resolves #365

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

