### PR TITLE
[Hotfix] KeyStoreException 

### DIFF
--- a/app/src/main/java/com/eatssu/android/di/SecurePrefsModule.kt
+++ b/app/src/main/java/com/eatssu/android/di/SecurePrefsModule.kt
@@ -2,6 +2,8 @@ package com.eatssu.android.di
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import timber.log.Timber
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,6 +18,21 @@ object SecurePrefsModule {
     @Provides
     @Singleton
     fun provideSecurePrefs(@ApplicationContext context: Context): SharedPreferences {
+        return try {
+            createSecurePrefs(context)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to create SecurePrefs. Resetting...")
+            FirebaseCrashlytics.getInstance().recordException(e)
+
+            // Clear data
+            context.deleteSharedPreferences("secure_prefs")
+
+            // Retry
+            createSecurePrefs(context)
+        }
+    }
+
+    private fun createSecurePrefs(context: Context): SharedPreferences {
         val masterKey = androidx.security.crypto.MasterKey.Builder(context)
             .setKeyScheme(androidx.security.crypto.MasterKey.KeyScheme.AES256_GCM)
             .build()


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
> SecurePrefs KeyStoreException 해결 및 데이터 복구
 KeyStoreException 발생시 앱이 계속 죽어서 실행조차 안 됨. @HI-JIN2도 DEV모드지만 동일한 현상을 겪었음

KeyStoreException (특히 "Signature/MAC verification failed") 발생 시 앱이 강제 종료되지 않고, 손상된 키나 데이터를 삭제한 후 재설정(Graceful Degradation)하여 앱을 정상적으로 사용할 수 있도록 합니다.

키 저장소 오류가 발생하면 저장된 모든 암호화된 데이터(로그인 토큰 등)가 초기화됩니다.

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->

|As-is|To-Be|
|--|--|
| KeyStoreException 발생시 앱이 계속 죽어서 실행조차 안 됨. 캐시 및 데이터 밀면 되는데 사용자는 이를 모름. | KeyStoreException 발생시 자동으로EncryptedSharedPreferences를 삭제하고 다시 생성 |

### KeyStoreException 또는 GeneralSecurityException 발생 시 
1.  에러를 로그(Timber.e) 및 Crashlytics(recordException)에 리포팅 
2. 기존의 손상된 SharedPreferences 파일(secure_prefs.xml)을 삭제 
3. MasterKey도 리셋을 시도(키 자체가 손상되었을 수 있음)
4. EncryptedSharedPreferences를 다시 생성하여 반환

## Issue

- Resolves #468 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

