### PR TITLE
[Fix] Firebase App Tester(App Distribution)에 QA 파일 올라갔다는 사실을 slackbot봇으로 전송

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -149,3 +149,25 @@ jobs:
             issue_number: context.payload.pull_request.number,
             body,
           });
+
+    - name: Slack notification for App Distribution
+      if: success()
+      uses: 8398a7/action-slack@v3
+      with:
+        status: success
+        text: |
+          🔥 Firebase App Distribution 배포 완료!
+          
+          PR: #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
+          브랜치: ${{ github.event.pull_request.head.ref }}
+          테스터 그룹: eat-ssu-android-qa
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'good',
+              text: '🔥 Firebase App Distribution 배포 완료!\n\nPR: #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}\n브랜치: ${{ github.event.pull_request.head.ref }}\n테스터 그룹: eat-ssu-android-qa'
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_APP_DISTRIBUTION_WEBHOOK_URL }}
+

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -169,5 +169,5 @@ jobs:
             }]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_APP_DISTRIBUTION_WEBHOOK_URL }}
 

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -169,5 +169,5 @@ jobs:
             }]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_APP_DISTRIBUTION_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
Firebase App Tester(App Distribution)에 QA 파일 올라갔다는 사실을 `#01-qa-android` 채널로 슬랙 전송

- 참고: release 브랜치에 커밋이 push될때마다 Firebase App Tester 배포됨
- 의의: 실 배포뿐만 아니라 QA용 배포에 대해서도 ⭐️완전 자동화⭐️