### PR TITLE
[Fix] collegeId=-1일시 API 요청 안되게 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoActivity.kt
@@ -177,7 +177,7 @@ class UserInfoActivity :
         val data = state.data
 
         // 단과대를 먼저 선택하도록 유도
-        if (data.selectedCollege == null) {
+        if (data.selectedCollege == null || data.selectedCollege.collegeId == -1) {
             showToast(R.string.toast_college_required, ToastType.ERROR)
             return
         }

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/userinfo/UserInfoViewModel.kt
@@ -57,11 +57,14 @@ class UserInfoViewModel @Inject constructor(
 
             val userInfo = getUserCollegeDepartmentUseCase()
 
+            val initialCollege = userInfo.userCollege.takeUnless { it.collegeId == -1 }
+            val initialDepartment = userInfo.userDepartment.takeUnless { it.departmentId == -1 }
+
             // 단과대 목록과 학과 목록을 먼저 모두 가져옴
             val colleges = userRepository.getTotalColleges()
             val departments =
-                if (userInfo.userCollege.collegeId != -1)
-                    userRepository.getTotalDepartments(userInfo.userCollege.collegeId)
+                if (initialCollege != null)
+                    userRepository.getTotalDepartments(initialCollege.collegeId)
                 else
                     emptyList()
 
@@ -71,10 +74,10 @@ class UserInfoViewModel @Inject constructor(
                     UserInfoData(
                         nickname = userInfo.nickname,
                         originalNickname = userInfo.nickname,
-                        selectedCollege = userInfo.userCollege,
-                        originalCollege = userInfo.userCollege,
-                        selectedDepartment = userInfo.userDepartment,
-                        originalDepartment = userInfo.userDepartment,
+                        selectedCollege = initialCollege,
+                        originalCollege = initialCollege,
+                        selectedDepartment = initialDepartment,
+                        originalDepartment = initialDepartment,
                         collegeList = colleges,
                         departmentList = departments
                     )
@@ -186,6 +189,14 @@ class UserInfoViewModel @Inject constructor(
     fun loadDepartmentList(collegeId: Int) {
         viewModelScope.launch {
             val currentState = _uiState.value as? UiState.Success ?: return@launch
+
+            if (collegeId == -1) {
+                Timber.w("학과 목록 로드 스킵: invalid collegeId=-1")
+                _uiState.update {
+                    UiState.Success(currentState.data.copy(departmentList = emptyList()))
+                }
+                return@launch
+            }
 
             val departments = userRepository.getTotalDepartments(collegeId)
             _uiState.update {
@@ -305,4 +316,3 @@ data class UserInfoData(
             }
         }
 }
-


### PR DESCRIPTION
## Summary
* 운영 환경에서 `collegeId=-1`이 포함된 상태로 API 요청이 발생하여 `VALIDATION_ERROR` 예외가 발생함

```
- 예외 상태코드: VALIDATION_ERROR
- 예외 메시지: 입력값을 확인해주세요.
- 개발환경: prod

요청 정보
- HTTP Method: GET
- URI: /users/lookup/departments
- User ID: 4663
- 로그 내용 (파라미터 정보 포함): userId=4663, deviceType=ANDROID, collegeId=-1
===================
```


## Describe your changes

* 사용자 정보 입력 플로우에서 `collegeId` 또는 `departmentId`의 sentinel 값 `-1`을 **미선택 상태**로 간주하도록 처리
* `collegeId == -1`인 경우 `GET /users/lookup/departments` API를 호출하지 않도록 수정
  → 서버에서 `VALIDATION_ERROR` 발생 방지
