### PR TITLE
[Feat] deploy-eatssu 릴리즈 자동화 스킬 추가

### DIFF
--- a/.agent/skills/deploy-eatssu/SKILL.md
+++ b/.agent/skills/deploy-eatssu/SKILL.md
@@ -40,6 +40,8 @@ git tag --list | sort -V | tail -5
 - `versionName`: Semantic Versioning (`X.Y.Z`)
 - `versionCode`: 정수, 항상 +1 증가
 - 태그 형식: `X.Y.Z` (v 접두사 없음)
+- 릴리즈 노트 파일명: `release-notes/v<버전>.yml` (v 접두사 포함)
+→ 태그는 v 없이, 릴리즈 노트 파일명은 v 포함
 
 ### Step 2: 변경사항 파악
 

--- a/.agent/skills/deploy-eatssu/SKILL.md
+++ b/.agent/skills/deploy-eatssu/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: deploy-eatssu
+description: EAT-SSU Android 앱 릴리즈 자동화. 버전 범프, 릴리즈 노트 작성, release 브랜치 생성, PR 생성까지 전체 배포 플로우를 실행한다. "배포", "릴리즈", "release", "deploy", "출시", "버전 올려" 등의 키워드에 반응.
+version: 1.0.0
+---
+
+# Deploy EAT-SSU
+
+EAT-SSU Android 앱의 Google Play Store 릴리즈를 자동화하는 스킬.
+
+## 트리거
+
+사용자가 다음과 같이 요청할 때 이 스킬을 사용한다:
+- "배포해줘", "릴리즈 만들어줘", "출시해줘"
+- "버전 올려줘", "X.Y.Z 버전 만들어줘"
+- "release 브랜치 만들어줘"
+- "deploy", "release", "publish"
+
+## 전제 조건
+
+- `develop` 브랜치가 최신 상태여야 한다
+- 새 버전 번호가 필요하다 (사용자 지정 또는 자동 결정)
+
+## 릴리즈 플로우
+
+### Step 1: 버전 결정
+
+사용자가 버전을 지정하지 않았으면, 현재 버전을 확인하고 적절한 다음 버전을 제안한다.
+
+```bash
+# 현재 버전 확인
+grep 'versionName' app/build.gradle.kts | head -1
+grep 'versionCode' app/build.gradle.kts | head -1
+
+# 최신 태그 확인
+git tag --list | sort -V | tail -5
+```
+
+버전 규칙:
+- `versionName`: Semantic Versioning (`X.Y.Z`)
+- `versionCode`: 정수, 항상 +1 증가
+- 태그 형식: `X.Y.Z` (v 접두사 없음)
+
+### Step 2: 변경사항 파악
+
+직전 릴리즈 태그 이후의 커밋을 분석한다.
+
+```bash
+# 이전 태그 이후 커밋 목록 (머지 커밋 제외)
+git log <이전태그>..develop --oneline --no-merges
+
+# 변경된 파일 통계
+git diff <이전태그>..develop --stat
+```
+
+각 커밋의 의미를 파악하여:
+- 사용자에게 보이는 변경 (Feat, Fix) → 릴리즈 노트에 포함
+- 내부 변경 (Refactor, CI/CD, Chore) → 릴리즈 노트에서 제외하되 PR 본문에는 포함
+
+### Step 3: develop 브랜치에서 release 브랜치 생성
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b release/<버전>
+```
+
+### Step 4: 버전 범프
+
+`app/build.gradle.kts`의 `defaultConfig` 블록에서:
+
+```kotlin
+versionCode = <기존 + 1>
+versionName = "<새 버전>"
+```
+
+### Step 5: 릴리즈 노트 작성
+
+`release-notes/v<버전>.yml` 파일을 생성한다.
+
+형식:
+```yaml
+ko: |
+  - 한국어 릴리즈 노트 항목
+en: |
+  - English release note item
+```
+
+규칙 (반드시 준수):
+1. 각 항목은 `-`로 시작
+2. **한국어와 영어 모두 작성 필수**
+3. 개발자 용어 사용 금지 — 사용자 친화적 언어 사용
+4. 최소 10자 이상의 내용
+5. CI/CD, 리팩토링 등 사용자에게 보이지 않는 변경은 "앱의 안정성과 성능을 개선했어요" 류로 통합
+6. 이 내용이 **Google Play Store에 그대로 업로드**됨 (ko → Korea, en → Global)
+
+### Step 6: 커밋
+
+```bash
+git add app/build.gradle.kts release-notes/v<버전>.yml
+git commit -m "release: <버전>"
+```
+
+커밋 메시지는 반드시 `release: X.Y.Z` 형식을 사용한다.
+
+### Step 7: 푸시 & PR 생성
+
+```bash
+git push -u origin release/<버전>
+```
+
+PR 생성:
+- **base**: `develop`
+- **head**: `release/<버전>`
+- **title**: `release: <버전>`
+- **body**: 아래 템플릿 사용
+
+```markdown
+## Release <버전>
+
+### 변경사항 (<이전버전> → <새버전>)
+
+| 커밋 | 설명 | PR |
+|------|------|----|
+| `<hash>` | <커밋 메시지> | #<PR번호> |
+| ... | ... | ... |
+
+### 릴리즈 노트 (Play Store)
+
+**한국어**
+- <릴리즈 노트 항목들>
+
+**English**
+- <릴리즈 노트 항목들>
+
+### 버전 정보
+- `versionCode`: <이전> → <새>
+- `versionName`: <이전버전> → <새버전>
+```
+
+## PR 머지 후 자동 처리
+
+PR이 `develop`에 머지되면 GitHub Actions (`release.yml`)가 자동으로:
+
+1. Fastlane으로 Release AAB 빌드
+2. Google Play Store `production` 트랙에 배포
+3. GitHub Release 생성 (태그 + 자동 릴리즈 노트 + AAB 첨부)
+4. Slack 알림 전송
+
+## 수동 배포 (workflow_dispatch)
+
+GitHub Actions 탭에서 직접 실행도 가능:
+1. Actions → **Production Release** 워크플로우
+2. **Run workflow** 클릭
+3. `version`, `track` (internal/alpha/beta/production), `release_notes` 입력
+
+## 주의사항
+
+- **절대 `main`/`master`에 직접 푸시하지 않는다** — 항상 PR을 통해 머지
+- 릴리즈 노트 YAML 파일이 없거나 내용이 부족하면 Play Store 배포가 실패할 수 있다
+- `versionCode`는 Play Store에서 고유해야 하므로 **반드시 증가**시킨다
+- GitHub Secrets가 올바르게 설정되어 있어야 CI/CD가 동작한다

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,22 +184,34 @@ jobs:
           if [ -f "$RELEASE_NOTE_FILE" ]; then
             echo "✅ $RELEASE_NOTE_FILE 파일 발견"
             echo "exists=true" >> $GITHUB_OUTPUT
-            
-            RELEASE_NOTES_CONTENT=$(ruby -e "require 'yaml'; begin; puts YAML.load_file('$RELEASE_NOTE_FILE')['ko']; rescue; end")
-            
-            if [ -z "$RELEASE_NOTES_CONTENT" ]; then
-               echo "⚠️ YAML 파일에서 'ko' 항목을 찾을 수 없거나 비어있습니다."
-               echo "release_notes=" >> $GITHUB_OUTPUT
-            else
-               echo "release_notes<<EOF" >> $GITHUB_OUTPUT
-               echo "$RELEASE_NOTES_CONTENT" >> $GITHUB_OUTPUT
-               echo "EOF" >> $GITHUB_OUTPUT
-               echo "📄 릴리즈 노트 내용:"
-               echo "$RELEASE_NOTES_CONTENT"
+
+            RELEASE_NOTES_KO=$(ruby -e "require 'yaml'; begin; data = YAML.load_file('$RELEASE_NOTE_FILE') || {}; puts((data['ko-KR'] || data['ko'] || '').to_s); rescue; end")
+            RELEASE_NOTES_EN=$(ruby -e "require 'yaml'; begin; data = YAML.load_file('$RELEASE_NOTE_FILE') || {}; puts((data['en-US'] || data['en'] || '').to_s); rescue; end")
+
+            if [ -z "$RELEASE_NOTES_KO" ]; then
+               echo "⚠️ YAML 파일에서 한국어 릴리즈 노트(ko/ko-KR)를 찾지 못했습니다."
             fi
+
+            if [ -z "$RELEASE_NOTES_EN" ]; then
+               echo "⚠️ YAML 파일에서 영어 릴리즈 노트(en/en-US)를 찾지 못했습니다."
+            fi
+
+            echo "release_notes_ko<<EOF" >> $GITHUB_OUTPUT
+            echo "$RELEASE_NOTES_KO" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+
+            echo "release_notes_en<<EOF" >> $GITHUB_OUTPUT
+            echo "$RELEASE_NOTES_EN" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+
+            echo "📄 한국어 릴리즈 노트:"
+            echo "$RELEASE_NOTES_KO"
+            echo "📄 영어 릴리즈 노트:"
+            echo "$RELEASE_NOTES_EN"
           else
             echo "⚠️ $RELEASE_NOTE_FILE 파일을 찾을 수 없습니다."
-            echo "release_notes=" >> $GITHUB_OUTPUT
+            echo "release_notes_ko=" >> $GITHUB_OUTPUT
+            echo "release_notes_en=" >> $GITHUB_OUTPUT
           fi
 
       - name: Find previous tag for release notes
@@ -311,9 +323,13 @@ jobs:
             
             버전명: ${{ steps.extract_info.outputs.version }}
             
-            PlayStore 릴리즈 노트
+            PlayStore 릴리즈 노트 (KO)
             
-            ${{ steps.check_release_notes.outputs.release_notes != '' && steps.check_release_notes.outputs.release_notes || '릴리즈 노트가 없습니다.' }}
+            ${{ steps.check_release_notes.outputs.release_notes_ko != '' && steps.check_release_notes.outputs.release_notes_ko || '한국어 릴리즈 노트가 없습니다.' }}
+
+            PlayStore 릴리즈 노트 (EN)
+
+            ${{ steps.check_release_notes.outputs.release_notes_en != '' && steps.check_release_notes.outputs.release_notes_en || 'English release notes are missing.' }}
             
             GitHub 릴리즈노트
             
@@ -322,7 +338,7 @@ jobs:
             {
               attachments: [{
                 color: '${{ job.status }}' === 'success' ? 'good' : 'danger',
-                text: '[Android 업데이트 올렸습니다!]\n\n버전명: ${{ steps.extract_info.outputs.version }}\n\nPlayStore 릴리즈 노트\n\n${{ steps.check_release_notes.outputs.release_notes != '' && steps.check_release_notes.outputs.release_notes || '릴리즈 노트가 없습니다.' }}\n\nGitHub 릴리즈노트\n\n${{ steps.github_release_notes.outputs.github_notes != '' && steps.github_release_notes.outputs.github_notes || '- [Fix] 릴리즈 노트를 가져올 수 없습니다.' }}'
+                text: '[Android 업데이트 올렸습니다!]\n\n버전명: ${{ steps.extract_info.outputs.version }}\n\nPlayStore 릴리즈 노트 (KO)\n\n${{ steps.check_release_notes.outputs.release_notes_ko != '' && steps.check_release_notes.outputs.release_notes_ko || '한국어 릴리즈 노트가 없습니다.' }}\n\nPlayStore 릴리즈 노트 (EN)\n\n${{ steps.check_release_notes.outputs.release_notes_en != '' && steps.check_release_notes.outputs.release_notes_en || 'English release notes are missing.' }}\n\nGitHub 릴리즈노트\n\n${{ steps.github_release_notes.outputs.github_notes != '' && steps.github_release_notes.outputs.github_notes || '- [Fix] 릴리즈 노트를 가져올 수 없습니다.' }}'
               }]
             }
         env:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -169,6 +169,7 @@ platform :android do
           json_key: service_account_path,
           skip_upload_apk: true,
           skip_upload_metadata: true,
+          skip_upload_changelogs: false,
           skip_upload_images: true,
           skip_upload_screenshots: true
         }
@@ -280,23 +281,33 @@ platform :android do
 
     require 'yaml'
     begin
-      release_notes_data = YAML.load_file(yaml_file)
-      ko_notes = release_notes_data['ko']
-      en_notes = release_notes_data['en']
+      release_notes_data = YAML.load_file(yaml_file) || {}
+      unless release_notes_data.is_a?(Hash)
+        UI.error("❌ YAML 릴리즈 노트 형식이 올바르지 않습니다. key-value 구조가 필요합니다.")
+        return nil
+      end
 
-      if ko_notes.nil? || ko_notes.strip.empty?
+      normalize_notes = lambda do |value|
+        note = value.to_s.strip
+        note.empty? ? nil : note
+      end
+
+      ko_notes = normalize_notes.call(release_notes_data['ko-KR']) || normalize_notes.call(release_notes_data['ko'])
+      en_notes = normalize_notes.call(release_notes_data['en']) || normalize_notes.call(release_notes_data['en-US'])
+
+      if ko_notes.nil?
         UI.error("❌ 한국어 릴리즈 노트가 비어있습니다.")
         ko_notes = "버그 수정 및 성능 개선"
       end
 
-      if en_notes.nil? || en_notes.strip.empty?
+      if en_notes.nil?
         UI.error("❌ 영어 릴리즈 노트가 비어있습니다.")
         en_notes = "Bug fixes and performance improvements"
       end
 
       return {
-        'ko-KR' => ko_notes.strip,
-        'en-US' => en_notes.strip
+        'ko-KR' => ko_notes,
+        'en-US' => en_notes,
       }
     rescue => e
       UI.error("❌ YAML 파일 파싱 실패: #{e.message}")
@@ -368,6 +379,7 @@ platform :android do
           json_key: service_account_path,
           skip_upload_apk: true,
           skip_upload_metadata: true,
+          skip_upload_changelogs: false,
           # 메타데이터 경로 지정 (릴리즈 노트 포함)
           metadata_path: metadata_dir,
           skip_upload_images: true,
@@ -458,6 +470,7 @@ platform :android do
           json_key: service_account_path,
           skip_upload_apk: true,
           skip_upload_metadata: true,
+          skip_upload_changelogs: false,
           metadata_path: metadata_dir,
           skip_upload_images: true,
           skip_upload_screenshots: true


### PR DESCRIPTION
## Summary

- EAT-SSU Android 앱의 릴리즈 플로우를 자동화하는 AI 에이전트 스킬(`deploy-eatssu`)을 추가합니다.
- 버전 범프, 릴리즈 노트 작성, release 브랜치 생성, PR 생성까지 전체 배포 과정을 스킬 하나로 실행할 수 있습니다.

## 변경 내용

| 파일 | 설명 |
|------|------|
| `.agent/skills/deploy-eatssu/SKILL.md` | 릴리즈 자동화 스킬 정의 |

## 상세

- 트리거: "배포해줘", "릴리즈 만들어줘", "버전 올려줘" 등
- 플로우: 버전 결정 → 변경사항 파악 → release 브랜치 생성 → 버전 범프 → 릴리즈 노트(ko/en) 작성 → 커밋 → 푸시 & PR 생성
- 기존 Fastlane + GitHub Actions CI/CD 파이프라인과 연동