### PR TITLE
[Fix] xxxReviewListResponse의 non-null List 디코딩 문제를 해결합니다

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MealReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MealReviewListResponse.kt
@@ -8,19 +8,19 @@ import kotlinx.serialization.Serializable
 data class MealReviewListResponse(
     @SerialName("numberOfElements") val numberOfElements: Int? = null,
     @SerialName("hasNext") val hasNext: Boolean? = null,
-    @SerialName("dataList") val dataList: List<DataList> = arrayListOf()
+    @SerialName("dataList") val dataList: List<DataList> = listOf()
 ) {
     @Serializable
     data class DataList(
         @SerialName("reviewId") val reviewId: Long? = null,
-        @SerialName("menuList") val menuList: List<MenuList> = arrayListOf(),
+        @SerialName("menuList") val menuList: List<MenuList?> = listOf(),
         @SerialName("writerId") val writerId: Long? = null,
         @SerialName("isWriter") val isWriter: Boolean? = null,
         @SerialName("writerNickname") val writerNickname: String? = null,
         @SerialName("rating") val rating: Int? = null,
         @SerialName("writtenAt") val writtenAt: String? = null,
         @SerialName("content") val content: String? = null,
-        @SerialName("imageUrls") val imageUrls: List<String> = arrayListOf(),
+        @SerialName("imageUrls") val imageUrls: List<String?> = listOf(),
     ) {
         @Serializable
         data class MenuList(
@@ -38,7 +38,7 @@ fun MealReviewListResponse?.toDomain(): List<Review> {
         Review(
             reviewId = data.reviewId ?: -1L,
             isWriter = data.isWriter ?: false,
-            menuLikeInfoList = data.menuList.map { menu ->
+            menuLikeInfoList = data.menuList.filterNotNull().map { menu ->
                 Review.MenuLikeInfo(
                     menuId = menu.id ?: -1L,
                     name = menu.name ?: "",
@@ -49,7 +49,7 @@ fun MealReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.firstOrNull(),
+            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
         )
     } ?: emptyList()
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MealReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MealReviewListResponse.kt
@@ -49,7 +49,7 @@ fun MealReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
+            imgUrl = data.imageUrls.firstOrNull { it != null },
         )
     } ?: emptyList()
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MenuReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MenuReviewListResponse.kt
@@ -47,7 +47,7 @@ fun MenuReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
+            imgUrl = data.imageUrls.firstOrNull { it != null },
         )
     } ?: emptyList()
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MenuReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MenuReviewListResponse.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class MenuReviewListResponse(
     @SerialName("numberOfElements") val numberOfElements: Int? = null,
     @SerialName("hasNext") val hasNext: Boolean? = null,
-    @SerialName("dataList") val dataList: List<DataList> = arrayListOf(),
+    @SerialName("dataList") val dataList: List<DataList> = listOf(),
 ) {
     @Serializable
     data class DataList(
@@ -20,7 +20,7 @@ data class MenuReviewListResponse(
         @SerialName("rating") val rating: Int? = null,
         @SerialName("writtenAt") val writtenAt: String? = null,
         @SerialName("content") val content: String? = null,
-        @SerialName("imageUrls") val imageUrls: List<String> = arrayListOf(),
+        @SerialName("imageUrls") val imageUrls: List<String?> = listOf(),
     ) {
         @Serializable
         data class Menu(
@@ -47,7 +47,7 @@ fun MenuReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.firstOrNull(),
+            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
         )
     } ?: emptyList()
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MyReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MyReviewListResponse.kt
@@ -45,7 +45,7 @@ fun MyReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
+            imgUrl = data.imageUrls.firstOrNull { it != null },
         )
     } ?: emptyList()
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/MyReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/MyReviewListResponse.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class MyReviewListResponse(
     @SerialName("numberOfElements") val numberOfElements: Int? = null,
     @SerialName("hasNext") val hasNext: Boolean? = null,
-    @SerialName("dataList") val dataList: ArrayList<DataList>? = arrayListOf()
+    @SerialName("dataList") val dataList: List<DataList>? = listOf()
 ) {
     @Serializable
     data class DataList(
@@ -17,8 +17,8 @@ data class MyReviewListResponse(
         @SerialName("rating") val rating: Int? = null,
         @SerialName("writtenAt") val writtenAt: String? = null,
         @SerialName("content") val content: String? = null,
-        @SerialName("imageUrls") val imageUrls: ArrayList<String> = arrayListOf(),
-        @SerialName("menuList") val menuList: ArrayList<MenuList> = arrayListOf()
+        @SerialName("imageUrls") val imageUrls: List<String?> = listOf(),
+        @SerialName("menuList") val menuList: List<MenuList?> = listOf()
     ) {
         @Serializable
         data class MenuList(
@@ -34,7 +34,7 @@ fun MyReviewListResponse?.toDomain(): List<Review> {
         Review(
             reviewId = data.reviewId ?: -1L,
             isWriter = true,
-            menuLikeInfoList = data.menuList.map { menu ->
+            menuLikeInfoList = data.menuList.filterNotNull().map { menu ->
                 Review.MenuLikeInfo(
                     menuId = menu.id ?: -1L,
                     name = menu.name ?: "",
@@ -45,7 +45,7 @@ fun MyReviewListResponse?.toDomain(): List<Review> {
             rating = data.rating ?: 0,
             writeDate = data.writtenAt ?: "",
             content = data.content ?: "",
-            imgUrl = data.imageUrls.firstOrNull(),
+            imgUrl = data.imageUrls.filterNotNull().firstOrNull(),
         )
     } ?: emptyList()
 }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
백엔드 API 응답에서 imageUrls나 menuList 배열 내부에 null 값이 포함되어 내려왔을 때, 
kotlinx.serialization이 non-null 리스트(List<String>)로 디코딩하려고 시도하면서 발생한 문제
> #467 kotlinx.serialization 변경으로 인한 파생 에러
> 3.3 고구마치즈돈까스 선택시 발생 (기타 더 있겠지만 재현 이걸로함)

```

 ApiResultCall - onFailure called
kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 464: Expected string literal but 'null' literal was found at path: $.result.dataList[1].imageUrls[0]
```


| as-is|to-be|
|--|--|
| 앱이 꺼지진 않으나 일부 리뷰 리스트 파싱 안됨 | 파싱 잘됨|
|<img width="340" height="680" alt="스크린샷 2026-03-03 오전 10 59 50" src="https://github.com/user-attachments/assets/c48c6682-fbb6-4256-966e-b04fc8b1d08e" />|<img width="340" height="680" alt="스크린샷 2026-03-03 오전 11 04 26" src="https://github.com/user-attachments/assets/2f8df2b9-2ba8-4257-abfc-c5b0cff16a38" /> |

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
다음 파일들의 리스트 속성을 nullable(List<String?>, List<MenuList?>)로 변경하고, 이를 도메인 모델로 변환할 때(예: toDomain()) filterNotNull() 연산자를 추가하여 null 값을 안전하게 무시하도록 처리했습니다
1. MealReviewListResponse.kt
2. MenuReviewListResponse.kt
3. MyReviewListResponse.kt


## Issue

- [MealReviewListResponse$DataList$$serializer.deserialize
](https://console.firebase.google.com/project/eat-ssu-2023/crashlytics/app/android:com.eatssu.android/issues/751f7fc6bb4d14f0bb9abdedba855eb2?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_NONFATAL_ISSUE&time=7d&sessionEventKey=69A5E3D001E7000178F55F9A8587A1BF_2191187022508761053)

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

잔존해있는 ArrayList를 List로 변경하고 디폴트 값도 lisfOf로 바꾸었습니다