### PR TITLE
[Fix] MenuType enum의 llegalArgumentException을 예방합니다

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
@@ -40,15 +40,7 @@ class ReviewComposeActivity : ComponentActivity() {
         setContent {
             EatssuTheme {
                 val navHostController = rememberNavController()
-
-                val parsedMenuType = runCatching {
-                    if (menuType.isNullOrBlank()) null else MenuType.valueOf(menuType!!)
-                }.onFailure { exception ->
-                    Timber.e(exception, "Failed to parse MenuType: \$menuType")
-                    FirebaseCrashlytics.getInstance().recordException(
-                        IllegalArgumentException("Invalid MenuType '\$menuType' for itemId \$itemId. Original exception: \${exception.message}", exception)
-                    )
-                }.getOrNull()
+                val parsedMenuType = MenuType.entries.find { it.name == menuType }
 
                 parsedMenuType?.let { type ->
                     ReviewNav(
@@ -59,7 +51,7 @@ class ReviewComposeActivity : ComponentActivity() {
                         onExit = { finish() }
                     )
                 } ?: run {
-                    Timber.e("Invalid or null MenuType received: \$menuType")
+                    Timber.e("Invalid or null MenuType received: $menuType")
                     ErrorScreen(
                         onBackClick = { finish() }
                     )

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
@@ -3,21 +3,25 @@ package com.eatssu.android.presentation.cafeteria.review
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
-import com.eatssu.android.presentation.cafeteria.review.ReviewNav
 import com.eatssu.common.enums.MenuType
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.eatssu.design_system.theme.EatssuTheme
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import kotlin.properties.Delegates
@@ -31,6 +35,8 @@ class ReviewComposeActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        getIntents() // 컴포즈 화면 그리기 전에 호출
+
         setContent {
             EatssuTheme {
                 val navHostController = rememberNavController()
@@ -60,7 +66,6 @@ class ReviewComposeActivity : ComponentActivity() {
                 }
             }
         }
-        getIntents()
     }
 
     private fun getIntents() { //todo 추후 변경

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
@@ -3,9 +3,20 @@ package com.eatssu.android.presentation.cafeteria.review
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.eatssu.android.presentation.cafeteria.review.ReviewNav
 import com.eatssu.common.enums.MenuType
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.eatssu.design_system.theme.EatssuTheme
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -26,6 +37,11 @@ class ReviewComposeActivity : ComponentActivity() {
 
                 val parsedMenuType = runCatching {
                     if (menuType.isNullOrBlank()) null else MenuType.valueOf(menuType!!)
+                }.onFailure { exception ->
+                    Timber.e(exception, "Failed to parse MenuType: \$menuType")
+                    FirebaseCrashlytics.getInstance().recordException(
+                        IllegalArgumentException("Invalid MenuType '\$menuType' for itemId \$itemId. Original exception: \${exception.message}", exception)
+                    )
                 }.getOrNull()
 
                 parsedMenuType?.let { type ->
@@ -38,7 +54,9 @@ class ReviewComposeActivity : ComponentActivity() {
                     )
                 } ?: run {
                     Timber.e("Invalid or null MenuType received: \$menuType")
-                    finish()
+                    ErrorScreen(
+                        onBackClick = { finish() }
+                    )
                 }
             }
         }
@@ -51,5 +69,33 @@ class ReviewComposeActivity : ComponentActivity() {
         itemName = intent.getStringExtra("itemName").toString().replace(Regex("[\\[\\]]"), "")
 
         Timber.d("메뉴는 $itemName $menuType $itemId")
+    }
+
+    @Composable
+    private fun ErrorScreen(onBackClick: () -> Unit) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "메뉴 정보를 불러오는데 실패했습니다.\n다시 시도해주세요.",
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onBackClick) {
+                Text(text = "뒤로가기")
+            }
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    private fun ErrorScreenPreview() {
+        EatssuTheme {
+            ErrorScreen(onBackClick = {})
+        }
     }
 }

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewComposeActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
+import com.eatssu.android.presentation.cafeteria.review.ReviewNav
 import com.eatssu.common.enums.MenuType
 import com.eatssu.design_system.theme.EatssuTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -13,7 +14,7 @@ import kotlin.properties.Delegates
 @AndroidEntryPoint
 class ReviewComposeActivity : ComponentActivity() {
 
-    private lateinit var menuType: String
+    private var menuType: String? = null
     private var itemId by Delegates.notNull<Long>()
     private lateinit var itemName: String
 
@@ -23,20 +24,29 @@ class ReviewComposeActivity : ComponentActivity() {
             EatssuTheme {
                 val navHostController = rememberNavController()
 
-                ReviewNav(
-                    navHostController = navHostController,
-                    menuType = MenuType.valueOf(menuType),
-                    menuName = itemName,
-                    id = itemId,
-                    onExit = { finish() }
-                )
+                val parsedMenuType = runCatching {
+                    if (menuType.isNullOrBlank()) null else MenuType.valueOf(menuType!!)
+                }.getOrNull()
+
+                parsedMenuType?.let { type ->
+                    ReviewNav(
+                        navHostController = navHostController,
+                        menuType = type,
+                        menuName = itemName,
+                        id = itemId,
+                        onExit = { finish() }
+                    )
+                } ?: run {
+                    Timber.e("Invalid or null MenuType received: \$menuType")
+                    finish()
+                }
             }
         }
         getIntents()
     }
 
     private fun getIntents() { //todo 추후 변경
-        menuType = intent.getStringExtra("menuType").toString()
+        menuType = intent.getStringExtra("menuType")
         itemId = intent.getLongExtra("itemId", 0)
         itemName = intent.getStringExtra("itemName").toString().replace(Regex("[\\[\\]]"), "")
 


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
> 재현 경로 못 찾겠음 

MenuType이 이전 화면에서 intent로 넘어오는데 정체모를원인으로 no enum으로 넘어오는듯함 
매번 그런게 아니라 어쩌다 한번으로 추정됨

|as-is|to-be|
|--|--|
| MenuType이 전달안되었을시 앱이 터짐 | 앱이 터지지 않고 에러뷰 처리|

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- lateinit 대신 기본값을 null로 해서 비정상 종료를 방지함
- 파이어베이스 로깅 추가
- 에러뷰 추가
<img width="223" height="459" alt="스크린샷 2026-03-03 오전 11 28 02" src="https://github.com/user-attachments/assets/ce969995-b6bf-4276-96ab-cc6dbd7c0de1" />

## Issue

- Resolves #434 
- [MenuType.valueOf - java.lang.IllegalArgumentException - No enum constant N4.c.null](https://console.firebase.google.com/project/eat-ssu-2023/crashlytics/app/android:com.eatssu.android/issues/30a2f150e1649a2863b0502672aaa1f6?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_NONFATAL_ISSUE&time=7d&sessionEventKey=69A59A82017600012F0354809EC15CA0_2191106240565333720)


## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

에러뷰 처리가 적절한지 확인해주세요!
