### PR TITLE
[Fix] 리뷰 작성 후 리뷰 리스트 화면에 돌아왔을때 방금 쓴 리뷰가 없는 문제를 해결해요

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewNav.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/ReviewNav.kt
@@ -1,6 +1,9 @@
 package com.eatssu.android.presentation.cafeteria.review
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -17,6 +20,8 @@ object ReviewNav {
     const val Modify = "modify"
 }
 
+private const val KEY_REVIEW_LIST_REFRESH_NONCE = "review_list_refresh_nonce"
+
 @Composable
 fun ReviewNav(
     navHostController: NavHostController = rememberNavController(),
@@ -31,11 +36,16 @@ fun ReviewNav(
         startDestination = ReviewNav.List
     ) {
         // 리뷰 보기
-        composable(ReviewNav.List) {
+        composable(ReviewNav.List) { backStackEntry ->
+            val refreshNonce by backStackEntry.savedStateHandle
+                .getStateFlow(KEY_REVIEW_LIST_REFRESH_NONCE, 0L)
+                .collectAsState()
+
             ReviewListScreen(
                 menuName = menuName,
                 menuType = menuType,
                 id = id,
+                refreshNonce = refreshNonce,
                 onBack = { onExit() },
                 onModifyClick = { review ->
                     // 선택된 리뷰 데이터를 Modify 화면으로 전달
@@ -54,6 +64,12 @@ fun ReviewNav(
                     }
                 }
             )
+
+            LaunchedEffect(refreshNonce) {
+                if (refreshNonce != 0L) {
+                    backStackEntry.savedStateHandle[KEY_REVIEW_LIST_REFRESH_NONCE] = 0L
+                }
+            }
         }
 
         // 리뷰 작성
@@ -62,7 +78,12 @@ fun ReviewNav(
                 menuType = menuType,
                 menuName = menuName,
                 id = id,
-                onBack = { navHostController.popBackStack() },
+                onBack = {
+                    navHostController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set(KEY_REVIEW_LIST_REFRESH_NONCE, System.currentTimeMillis())
+                    navHostController.popBackStack()
+                },
             )
         }
 

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListScreen.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListScreen.kt
@@ -77,6 +77,7 @@ fun ReviewListScreen(
     menuType: MenuType,
     menuName: String,
     id: Long,
+    refreshNonce: Long = 0L,
     onBack: () -> Unit = {},
     onWriteButtonClick: () -> Unit,
     onModifyClick: (Review) -> Unit,
@@ -93,6 +94,13 @@ fun ReviewListScreen(
     val reviewListState by viewModel.uiState.collectAsStateWithLifecycle()
     val reviewPagingItems = viewModel.reviewPagingData.collectAsLazyPagingItems()
     val uiEvent by viewModel.uiEvent.collectAsStateWithLifecycle(initialValue = null)
+
+    LaunchedEffect(refreshNonce) {
+        if (refreshNonce == 0L) return@LaunchedEffect
+        // 리뷰 작성 화면에서 돌아온 경우, 리스트/정보를 강제로 갱신한다.
+        viewModel.getReview(menuType, id)
+        reviewPagingItems.refresh()
+    }
 
     LaunchedEffect(uiEvent) {
         when (val event = uiEvent) {

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/list/ReviewListViewModel.kt
@@ -17,13 +17,13 @@ import com.eatssu.common.enums.MenuType
 import com.eatssu.common.enums.ToastType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,21 +41,24 @@ class ReviewListViewModel @Inject constructor(
     private val _uiEvent: MutableSharedFlow<UiEvent> = MutableSharedFlow()
     val uiEvent = _uiEvent.asSharedFlow()
 
-    private val _loadParams = MutableStateFlow<Pair<MenuType, Long>?>(null)
+    private val _loadParams = MutableSharedFlow<Pair<MenuType, Long>>(
+        replay = 1,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val reviewPagingData: Flow<PagingData<Review>> = _loadParams
-        .filterNotNull()
         .flatMapLatest { (menuType, itemId) ->
             getReviewListPagedUseCase(menuType, itemId)
         }
         .cachedIn(viewModelScope)
 
     fun getReview(menuType: MenuType, itemId: Long) {
-        // 파라미터 업데이트 시 페이징 흐름 트리거
-        // StateFlow는 동일한 값으로 설정되어도 업데이트되지 않으므로 별도의 체크 불필요
-        _loadParams.value = menuType to itemId
-        
+        // 동일 파라미터로 다시 진입(작성/수정 후 popBackStack)해도
+        // 항상 페이징 소스를 새로 만들 수 있도록 SharedFlow로 트리거한다.
+        _loadParams.tryEmit(menuType to itemId)
+
         viewModelScope.launch {
             loadReviewInfo(menuType, itemId)
         }
@@ -94,10 +97,8 @@ class ReviewListViewModel @Inject constructor(
             _uiEvent.emit(ReviewListEvent.ReviewDeleted)
 
             // 정보 갱신
-            val currentParams = _loadParams.value
-            if (currentParams != null) {
-                loadReviewInfo(currentParams.first, currentParams.second)
-            }
+            val currentParams = _loadParams.replayCache.lastOrNull()
+            if (currentParams != null) loadReviewInfo(currentParams.first, currentParams.second)
         }
     }
 }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
> Paging 이전에는 되었었는데 Paging 도입 후 안된 것으로 추정
- Navigation에서 ReviewListScreen이 백스택에 남아있어서 LaunchedEffect(menuType, id)가 popBackStack 후에 다시 안 돌아가는것이 원인
-  리뷰 작성 -> 뒤로가기 시점에 “리스트 화면에 새로고침 신호”를 보내고, 리스트가 다시 보일 때 paging refresh + info 재호출하도록  수정


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- ReviewNav.kt
  - Write 화면에서 나갈 때 previousBackStackEntry.savedStateHandle에 review_list_refresh_nonce 기록
  - List 화면에서 savedStateHandle.getStateFlow(...)로 nonce 감시 + 소비(0으로 리셋)
- ReviewListScreen.kt
  - refreshNonce가 바뀌면 viewModel.getReview(menuType, id) + reviewPagingItems.refresh() 실행
[리뷰반영-Screen_recording_20260306_122556.webm](https://github.com/user-attachments/assets/192006a7-ea03-45ab-a5b5-a772cd148091)

## Issue

- Resolves #495 

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

