### PR TITLE
[Fix] 식당 정보 바텀시트 Glide 크래시를 방지해요

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/info/InfoBottomSheetFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/info/InfoBottomSheetFragment.kt
@@ -5,14 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.eatssu.android.databinding.FragmentBottomsheetInfoBinding
 import com.eatssu.common.EventLogger
 import com.eatssu.common.enums.Restaurant
 import com.eatssu.common.enums.ScreenId
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -42,15 +41,16 @@ class InfoBottomSheetFragment : BottomSheetDialogFragment() {
 
         binding.tvName.text = getString(restaurantType.displayNameResId)
 
-        CoroutineScope(Dispatchers.Main).launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             val restaurantInfo = infoViewModel.getRestaurantInfo(restaurantType)
+            val binding = _binding ?: return@launch
 
             restaurantInfo?.let {
                 binding.tvLocation.text = it.location
                 binding.tvTime.text = it.time
                 binding.tvEtc.text = it.etc
 
-                Glide.with(this@InfoBottomSheetFragment)
+                Glide.with(binding.ivCafeteriaPhoto)
                     .load(it.image)
                     .into(binding.ivCafeteriaPhoto)
             }
@@ -60,6 +60,11 @@ class InfoBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onResume() {
         super.onResume()
         EventLogger.screenView(ScreenId.HOME_INFO)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     companion object {


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
바텀 시트를 닫은 직후 식당 이미지 로드가 이어지면 Fragment가 detach된 상태에서 `Glide.with(fragment)`가 호출되어 NPE가 발생했어요.

- `CoroutineScope(Dispatchers.Main)`로 띄운 작업이 view lifecycle과 분리되어 있어서 BottomSheet가 닫힌 뒤에도 UI 업데이트가 이어질 수 있었어요.
- 코루틴을 `viewLifecycleOwner.lifecycleScope`에 묶고, 뷰가 살아있을 때만 binding/Glide를 사용하도록 바꿨어요.

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- `InfoBottomSheetFragment.kt`
  - `CoroutineScope(Dispatchers.Main)`를 `viewLifecycleOwner.lifecycleScope`로 변경
  - 코루틴 재개 시 `_binding`이 null이면 바로 return 하도록 방어 로직 추가
  - `Glide.with(this@InfoBottomSheetFragment)` 대신 `Glide.with(binding.ivCafeteriaPhoto)`로 요청을 view에 묶음
  - `onDestroyView()`에서 binding 정리 추가

## Issue

- 관련 크래시: https://console.firebase.google.com/u/0/project/eat-ssu-2023/crashlytics/app/android:com.eatssu.android/issues/dde63d5f291d65f1f4e61a7ed90ccafd?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=7d&sessionEventKey=69AE301F003E000135576CC3E879430D_2193522584134032054