### PR TITLE
release: 3.2.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 58
-        versionName = "3.2.4"
+        versionCode = 59
+        versionName = "3.2.5"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.5.yml
+++ b/release-notes/v3.2.5.yml
@@ -1,0 +1,10 @@
+ko: |
+  - 나만아니면돼 이벤트 안내를 더 쉽게 확인할 수 있도록 팝업과 툴팁을 추가했어요.
+  - 리뷰를 작성한 뒤 목록 화면에서 방금 남긴 내용을 더 자연스럽게 확인할 수 있어요.
+  - 리뷰 작성 화면의 사진 선택 흐름을 다듬어 더 편하게 이용할 수 있어요.
+  - 일부 화면에서 발생하던 오류를 줄여 앱을 더 안정적으로 사용할 수 있어요.
+en: |
+  - Added a popup and tooltip so you can check the Anyone But Me event more easily.
+  - Made it easier to see your newly written review right away on the review list screen.
+  - Improved the photo selection flow on the review writing screen for a smoother experience.
+  - Reduced errors that could occur on some screens for a more stable app experience.


### PR DESCRIPTION
## Release 3.2.5

### 변경사항 (3.2.4 → 3.2.5)

| 커밋 | 설명 | PR |
|------|------|----|
| `bc020702` | [Feat] 나만아니면돼 이벤트 팝업, 툴팁 추가 | #498 |
| `38ecefbe` | fix: 바텀 시트가 닫힐 때 Coroutine이 삭제되어 발생하던 크래시 해결 | #497 |
| `abb16584` | [Fix] 리뷰 작성 후 리뷰 리스트 화면에 돌아왔을때 방금 쓴 리뷰가 없는 문제를 해결해요 | #493 |
| `27261d27` | [Fix] write review photo UI 수정 | #492 |
| `e1c4bccd` | [Fix] OSS Licenses 크래시 방지 | #489 |

### 릴리즈 노트 (Play Store)

**한국어**
- 나만아니면돼 이벤트 안내를 더 쉽게 확인할 수 있도록 팝업과 툴팁을 추가했어요.
- 리뷰를 작성한 뒤 목록 화면에서 방금 남긴 내용을 더 자연스럽게 확인할 수 있어요.
- 리뷰 작성 화면의 사진 선택 흐름을 다듬어 더 편하게 이용할 수 있어요.
- 일부 화면에서 발생하던 오류를 줄여 앱을 더 안정적으로 사용할 수 있어요.

**English**
- Added a popup and tooltip so you can check the Anyone But Me event more easily.
- Made it easier to see your newly written review right away on the review list screen.
- Improved the photo selection flow on the review writing screen for a smoother experience.
- Reduced errors that could occur on some screens for a more stable app experience.

### 버전 정보
- `versionCode`: 58 → 59
- `versionName`: 3.2.4 → 3.2.5