### PR TITLE
release: 3.2.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 60
-        versionName = "3.2.6"
+        versionCode = 61
+        versionName = "3.2.8"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.8.yml
+++ b/release-notes/v3.2.8.yml
@@ -1,0 +1,4 @@
+ko: |
+  - 단일 메뉴 리뷰가 정상적으로 등록되도록 오류를 수정했어요.
+en: |
+  - Fixed an issue where writing a review for a single menu item could fail.


### PR DESCRIPTION
## Release 3.2.8

### 변경사항 (3.2.6 → 3.2.8)

| 커밋 | 설명 | PR |
|------|------|----|
| `ffe737d6` | fix: 단일 메뉴 리뷰 작성 시 menuLike null 방지 | #504 |
| `b9b26651` | release: 3.2.8 | - |

### 릴리즈 노트 (Play Store)

**한국어**
- 단일 메뉴 리뷰가 정상적으로 등록되도록 오류를 수정했어요.

**English**
- Fixed an issue where writing a review for a single menu item could fail.

### 버전 정보
- `versionCode`: 60 → 61
- `versionName`: 3.2.6 → 3.2.8