### PR TITLE
[Refactor] domain 레이어에서 가지는 request dto 의존성을 제거합니다.

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/remote/repository/OauthRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/OauthRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.data.remote.repository
 
 import com.eatssu.android.data.model.ApiResult
-import com.eatssu.android.domain.model.ReissueTokenResult
 import com.eatssu.android.data.model.map
 import com.eatssu.android.data.model.orElse
 import com.eatssu.android.data.model.orNull
@@ -9,6 +8,7 @@ import com.eatssu.android.data.remote.dto.request.CheckValidTokenRequest
 import com.eatssu.android.data.remote.dto.request.LoginWithKakaoRequest
 import com.eatssu.android.data.remote.dto.response.toDomain
 import com.eatssu.android.data.remote.service.OauthService
+import com.eatssu.android.domain.model.ReissueTokenResult
 import com.eatssu.android.domain.model.Token
 import com.eatssu.android.domain.repository.OauthRepository
 import com.eatssu.common.enums.DeviceType
@@ -43,8 +43,8 @@ class OauthRepositoryImpl @Inject constructor(private val oauthService: OauthSer
             )
         ).map { it.toDomain() }.orNull()
 
-    override suspend fun checkValidToken(body: CheckValidTokenRequest): Boolean =
-        oauthService.checkValidToken(body).orElse(false)
+    override suspend fun checkValidToken(token: String): Boolean =
+        oauthService.checkValidToken(CheckValidTokenRequest(token)).orElse(false)
 }
 
 private fun String.asAuthorizationHeaderValue(): String =

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/ReportRepositoryImpl.kt
@@ -16,9 +16,9 @@ class ReportRepositoryImpl @Inject constructor(private val reportService: Report
     ): Boolean =
         reportService.reportReview(
             ReportRequest(
-                reviewId,
-                reportType,
-                content
+                reviewId = reviewId,
+                reportType = reportType,
+                content = content
             )
         ).isSuccess()
 

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/ReportRepositoryImpl.kt
@@ -9,7 +9,17 @@ import javax.inject.Inject
 class ReportRepositoryImpl @Inject constructor(private val reportService: ReportService) :
     ReportRepository {
 
-    override suspend fun reportReview(body: ReportRequest): Boolean =
-        reportService.reportReview(body).isSuccess()
+    override suspend fun reportReview(
+        reviewId: Long,
+        reportType: String,
+        content: String,
+    ): Boolean =
+        reportService.reportReview(
+            ReportRequest(
+                reviewId,
+                reportType,
+                content
+            )
+        ).isSuccess()
 
 }

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
@@ -23,7 +23,8 @@ class UserRepositoryImpl @Inject constructor(
         when (val result = userService.changeNickname(ChangeNicknameRequest(nickname))) {
             is ApiResult.Success -> Result.success(Unit)
             is ApiResult.Failure -> Result.failure(Exception(result.message ?: "닉네임 변경에 실패했어요."))
-            else -> Result.failure(Exception("닉네임 변경에 실패했어요."))
+            is ApiResult.NetworkError -> Result.failure(result.exception)
+            is ApiResult.UnknownError -> Result.failure(result.exception)
         }
 
     override suspend fun checkUserNameValidation(nickname: String): Result<Unit> {

--- a/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/repository/UserRepositoryImpl.kt
@@ -19,8 +19,8 @@ class UserRepositoryImpl @Inject constructor(
     private val userService: UserService
 ) : UserRepository {
 
-    override suspend fun updateUserName(body: ChangeNicknameRequest): Result<Unit> =
-        when (val result = userService.changeNickname(body)) {
+    override suspend fun updateUserName(nickname: String): Result<Unit> =
+        when (val result = userService.changeNickname(ChangeNicknameRequest(nickname))) {
             is ApiResult.Success -> Result.success(Unit)
             is ApiResult.Failure -> Result.failure(Exception(result.message ?: "닉네임 변경에 실패했어요."))
             else -> Result.failure(Exception("닉네임 변경에 실패했어요."))

--- a/app/src/main/java/com/eatssu/android/domain/repository/OauthRepository.kt
+++ b/app/src/main/java/com/eatssu/android/domain/repository/OauthRepository.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.domain.repository
 
 import com.eatssu.android.domain.model.ReissueTokenResult
-import com.eatssu.android.data.remote.dto.request.CheckValidTokenRequest
 import com.eatssu.android.domain.model.Token
 import com.eatssu.common.enums.DeviceType
 
@@ -16,5 +15,5 @@ interface OauthRepository {
         deviceType: DeviceType,
     ): Token?
 
-    suspend fun checkValidToken(body: CheckValidTokenRequest): Boolean
+    suspend fun checkValidToken(token: String): Boolean
 }

--- a/app/src/main/java/com/eatssu/android/domain/repository/ReportRepository.kt
+++ b/app/src/main/java/com/eatssu/android/domain/repository/ReportRepository.kt
@@ -1,11 +1,9 @@
 package com.eatssu.android.domain.repository
 
-import com.eatssu.android.data.remote.dto.request.ReportRequest
-import kotlinx.coroutines.flow.Flow
-
 interface ReportRepository {
     suspend fun reportReview(
-        body: ReportRequest,
+        reviewId: Long,
+        reportType: String,
+        content: String,
     ): Boolean
 }
-

--- a/app/src/main/java/com/eatssu/android/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/eatssu/android/domain/repository/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.eatssu.android.domain.repository
 
-import com.eatssu.android.data.remote.dto.request.ChangeNicknameRequest
 import com.eatssu.android.domain.model.College
 import com.eatssu.android.domain.model.Department
 
@@ -8,7 +7,7 @@ interface UserRepository {
 
     // 닉네임 변경
     suspend fun updateUserName(
-        body: ChangeNicknameRequest,
+        nickname: String,
     ): Result<Unit>
 
     // 유저 닉네임 중복 검사

--- a/app/src/main/java/com/eatssu/android/domain/usecase/auth/GetIsAccessTokenValidUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/auth/GetIsAccessTokenValidUseCase.kt
@@ -1,6 +1,5 @@
 package com.eatssu.android.domain.usecase.auth
 
-import com.eatssu.android.data.remote.dto.request.CheckValidTokenRequest
 import com.eatssu.android.domain.repository.OauthRepository
 import javax.inject.Inject
 
@@ -8,5 +7,5 @@ class GetIsAccessTokenValidUseCase @Inject constructor(
     private val oauthRepository: OauthRepository
 ) {
     suspend operator fun invoke(userAccessToken: String): Boolean =
-        oauthRepository.checkValidToken(CheckValidTokenRequest(userAccessToken))
+        oauthRepository.checkValidToken(userAccessToken)
 }

--- a/app/src/main/java/com/eatssu/android/domain/usecase/review/PostReportUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/review/PostReportUseCase.kt
@@ -9,7 +9,7 @@ class PostReportUseCase @Inject constructor(
     suspend operator fun invoke(
         reviewId: Long,
         reportType: String,
-        content: String
+        content: String,
     ): Boolean =
         reportRepository.reportReview(
             reviewId = reviewId,

--- a/app/src/main/java/com/eatssu/android/domain/usecase/review/PostReportUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/review/PostReportUseCase.kt
@@ -1,12 +1,19 @@
 package com.eatssu.android.domain.usecase.review
 
-import com.eatssu.android.data.remote.dto.request.ReportRequest
 import com.eatssu.android.domain.repository.ReportRepository
 import javax.inject.Inject
 
 class PostReportUseCase @Inject constructor(
     private val reportRepository: ReportRepository,
 ) {
-    suspend operator fun invoke(body: ReportRequest): Boolean =
-        reportRepository.reportReview(body)
+    suspend operator fun invoke(
+        reviewId: Long,
+        reportType: String,
+        content: String
+    ): Boolean =
+        reportRepository.reportReview(
+            reviewId = reviewId,
+            reportType = reportType,
+            content = content,
+        )
 }

--- a/app/src/main/java/com/eatssu/android/domain/usecase/user/SetUserNicknameUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/domain/usecase/user/SetUserNicknameUseCase.kt
@@ -1,28 +1,15 @@
 package com.eatssu.android.domain.usecase.user
 
 import com.eatssu.android.data.local.AccountDataStore
-import com.eatssu.android.data.remote.dto.request.ChangeNicknameRequest
 import com.eatssu.android.domain.repository.UserRepository
 import javax.inject.Inject
-
-//class SetUserNameUseCase @Inject constructor(
-//    private val userRepository: UserRepository,
-//    @ApplicationContext private val context: Context
-//) {
-//    suspend operator fun invoke(name: String): Flow<BaseResponse<Void>> {
-//        MySharedPreferences.setUserName(context, name)
-//        //Todo 이게 최선일까? 로컬에 이름 Set과 리모트의 이름 change를 usecase를 따로 만들어야하나?
-//
-//        return userRepository.updateUserName(ChangeNicknameRequest(name))
-//    }
-//}
 
 class SetUserNicknameUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val accountDataStore: AccountDataStore
 ) {
     suspend operator fun invoke(nickname: String): Result<Unit> {
-        val result = userRepository.updateUserName(ChangeNicknameRequest(nickname))
+        val result = userRepository.updateUserName(nickname)
         if (result.isSuccess) {
             // 서버 닉네임 변경이 성공한 경우에만 로컬 닉네임 변경
             accountDataStore.setName(nickname)

--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModel.kt
@@ -3,7 +3,6 @@ package com.eatssu.android.presentation.cafeteria.review.report
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eatssu.android.R
-import com.eatssu.android.data.remote.dto.request.ReportRequest
 import com.eatssu.android.domain.usecase.review.PostReportUseCase
 import com.eatssu.common.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,7 +28,7 @@ class ReportViewModel
         viewModelScope.launch {
             _uiState.update { it.copy(loading = true) }
 
-            val success = postReportUseCase(ReportRequest(reviewId, reportType, content))
+            val success = postReportUseCase(reviewId, reportType, content)
             if (!success) {
                 _uiState.update {
                     it.copy(

--- a/app/src/test/java/com/eatssu/android/data/remote/repository/OauthRepositoryImplBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/data/remote/repository/OauthRepositoryImplBehaviorSpec.kt
@@ -88,7 +88,7 @@ class OauthRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("성공값을 그대로 반환한다") {
                 runTest {
-                    repository.checkValidToken(body) shouldBe true
+                    repository.checkValidToken("access") shouldBe true
                 }
             }
         }
@@ -99,7 +99,7 @@ class OauthRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("기본값 false를 반환한다") {
                 runTest {
-                    repository.checkValidToken(body) shouldBe false
+                    repository.checkValidToken("access") shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/data/remote/repository/ReportRepositoryImplBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/data/remote/repository/ReportRepositoryImplBehaviorSpec.kt
@@ -27,7 +27,11 @@ class ReportRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("true를 반환한다") {
                 runTest {
-                    repository.reportReview(request) shouldBe true
+                    repository.reportReview(
+                        reviewId = request.reviewId,
+                        reportType = request.reportType,
+                        content = request.content,
+                    ) shouldBe true
                 }
             }
         }
@@ -37,7 +41,11 @@ class ReportRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("false를 반환한다") {
                 runTest {
-                    repository.reportReview(request) shouldBe false
+                    repository.reportReview(
+                        reviewId = request.reviewId,
+                        reportType = request.reportType,
+                        content = request.content,
+                    ) shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/data/remote/repository/UserRepositoryImplBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/data/remote/repository/UserRepositoryImplBehaviorSpec.kt
@@ -28,7 +28,7 @@ class UserRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("Result.success를 반환한다") {
                 runTest {
-                    repository.updateUserName(ChangeNicknameRequest("new")).isSuccess shouldBe true
+                    repository.updateUserName("new").isSuccess shouldBe true
                 }
             }
         }
@@ -40,7 +40,7 @@ class UserRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("서버 메시지를 포함한 실패 Result를 반환한다") {
                 runTest {
-                    val result = repository.updateUserName(ChangeNicknameRequest("new"))
+                    val result = repository.updateUserName("new")
                     result.isFailure shouldBe true
                     result.exceptionOrNull()?.message shouldBe "bad nickname"
                 }
@@ -54,7 +54,7 @@ class UserRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("기본 실패 메시지를 반환한다") {
                 runTest {
-                    val result = repository.updateUserName(ChangeNicknameRequest("new"))
+                    val result = repository.updateUserName("new")
                     result.isFailure shouldBe true
                     result.exceptionOrNull()?.message shouldBe "닉네임 변경에 실패했어요."
                 }
@@ -68,7 +68,7 @@ class UserRepositoryImplBehaviorSpec : AppBehaviorSpec({
 
             then("기본 실패 메시지를 반환한다") {
                 runTest {
-                    val result = repository.updateUserName(ChangeNicknameRequest("new"))
+                    val result = repository.updateUserName("new")
                     result.isFailure shouldBe true
                     result.exceptionOrNull()?.message shouldBe "닉네임 변경에 실패했어요."
                 }

--- a/app/src/test/java/com/eatssu/android/data/remote/repository/UserRepositoryImplBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/data/remote/repository/UserRepositoryImplBehaviorSpec.kt
@@ -66,11 +66,11 @@ class UserRepositoryImplBehaviorSpec : AppBehaviorSpec({
                 userService.changeNickname(ChangeNicknameRequest("new"))
             } returns ApiResult.UnknownError(IllegalStateException("boom"))
 
-            then("기본 실패 메시지를 반환한다") {
+            then("exception을 그대로 담은 실패 Result를 반환한다") {
                 runTest {
                     val result = repository.updateUserName("new")
                     result.isFailure shouldBe true
-                    result.exceptionOrNull()?.message shouldBe "닉네임 변경에 실패했어요."
+                    result.exceptionOrNull()?.message shouldBe "boom"
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/domain/usecase/auth/AuthDelegatingUseCasesBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/auth/AuthDelegatingUseCasesBehaviorSpec.kt
@@ -3,7 +3,6 @@ package com.eatssu.android.domain.usecase.auth
 import com.eatssu.android.data.local.AccountDataStore
 import com.eatssu.android.data.local.SettingDataStore
 import com.eatssu.android.data.local.TokenStore
-import com.eatssu.android.data.remote.dto.request.CheckValidTokenRequest
 import com.eatssu.android.domain.model.ReissueTokenResult
 import com.eatssu.android.domain.repository.OauthRepository
 import com.eatssu.android.domain.repository.UserRepository
@@ -20,7 +19,6 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 
@@ -163,13 +161,12 @@ class AuthDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
         val useCase = GetIsAccessTokenValidUseCase(oauthRepository)
 
         `when`("토큰 유효성 검사를 요청하면") {
-            val bodySlot = slot<CheckValidTokenRequest>()
-            coEvery { oauthRepository.checkValidToken(capture(bodySlot)) } returns true
+            coEvery { oauthRepository.checkValidToken("user-access-token") } returns true
 
-            then("CheckValidTokenRequest(token)으로 위임하고 결과를 반환한다") {
+            then("token으로 위임하고 결과를 반환한다") {
                 runTest {
                     useCase("user-access-token") shouldBe true
-                    bodySlot.captured.token shouldBe "user-access-token"
+                    coVerify(exactly = 1) { oauthRepository.checkValidToken("user-access-token") }
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
@@ -158,7 +158,7 @@ class ReviewDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
 
             then("false를 반환한다") {
                 runTest {
-                    useCase(reviewId, reportType, content) shouldBe false
+                    useCase(reviewId = reviewId, reportType = reportType, content = content) shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.domain.usecase.review
 
 import androidx.paging.PagingData
-import com.eatssu.android.data.remote.dto.request.ReportRequest
 import com.eatssu.android.domain.model.Review
 import com.eatssu.android.domain.repository.ReportRepository
 import com.eatssu.android.domain.repository.ReviewRepository
@@ -140,28 +139,26 @@ class ReviewDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
     given("PostReportUseCase") {
         val reportRepository = mockk<ReportRepository>()
         val useCase = PostReportUseCase(reportRepository)
-        val body = ReportRequest(
-            reviewId = 3L,
-            reportType = "SPAM",
-            content = "신고 사유",
-        )
+        val reviewId = 3L
+        val reportType = "SPAM"
+        val content = "신고 사유"
 
         `when`("신고가 성공하면") {
-            coEvery { reportRepository.reportReview(body) } returns true
+            coEvery { reportRepository.reportReview(reviewId, reportType, content) } returns true
 
             then("true를 반환한다") {
                 runTest {
-                    useCase(body) shouldBe true
+                    useCase(reviewId, reportType, content) shouldBe true
                 }
             }
         }
 
         `when`("신고가 실패하면") {
-            coEvery { reportRepository.reportReview(body) } returns false
+            coEvery { reportRepository.reportReview(reviewId, reportType, content) } returns false
 
             then("false를 반환한다") {
                 runTest {
-                    useCase(body) shouldBe false
+                    useCase(reviewId, reportType, content) shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/review/ReviewDelegatingUseCasesBehaviorSpec.kt
@@ -148,7 +148,7 @@ class ReviewDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
 
             then("true를 반환한다") {
                 runTest {
-                    useCase(reviewId, reportType, content) shouldBe true
+                    useCase(reviewId = reviewId, reportType = reportType, content = content) shouldBe true
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/domain/usecase/user/UserDelegatingUseCasesBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/user/UserDelegatingUseCasesBehaviorSpec.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.domain.usecase.user
 
 import com.eatssu.android.data.local.AccountDataStore
-import com.eatssu.android.data.remote.dto.request.ChangeNicknameRequest
 import com.eatssu.android.domain.repository.UserRepository
 import com.eatssu.android.test.AppBehaviorSpec
 import com.eatssu.android.test.sampleCollege
@@ -130,19 +129,18 @@ class UserDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
         val accountDataStore = mockk<AccountDataStore>()
         val useCase = SetUserNicknameUseCase(userRepository, accountDataStore)
         val nickname = "new-nick"
-        val request = ChangeNicknameRequest(nickname)
 
         coJustRun { accountDataStore.setName(nickname) }
 
         `when`("원격 닉네임 변경이 성공하면") {
-            coEvery { userRepository.updateUserName(request) } returns Result.success(Unit)
+            coEvery { userRepository.updateUserName(nickname) } returns Result.success(Unit)
 
             then("성공 결과를 반환하고 원격 성공 후 로컬 닉네임을 저장한다") {
                 runTest {
                     val result = useCase(nickname)
                     result.isSuccess shouldBe true
                     coVerifyOrder {
-                        userRepository.updateUserName(request)
+                        userRepository.updateUserName(nickname)
                         accountDataStore.setName(nickname)
                     }
                 }
@@ -150,13 +148,15 @@ class UserDelegatingUseCasesBehaviorSpec : AppBehaviorSpec({
         }
 
         `when`("원격 닉네임 변경이 실패하면") {
-            coEvery { userRepository.updateUserName(request) } returns Result.failure(IllegalStateException("fail"))
+            coEvery { userRepository.updateUserName(nickname) } returns Result.failure(
+                IllegalStateException("fail")
+            )
 
             then("실패 결과를 반환하고 로컬 닉네임은 변경하지 않는다") {
                 runTest {
                     val result = useCase(nickname)
                     result.isFailure shouldBe true
-                    coVerify(exactly = 1) { userRepository.updateUserName(request) }
+                    coVerify(exactly = 1) { userRepository.updateUserName(nickname) }
                     coVerify(exactly = 0) { accountDataStore.setName(any()) }
                 }
             }

--- a/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModelBehaviorSpec.kt
@@ -1,7 +1,6 @@
 package com.eatssu.android.presentation.cafeteria.review.report
 
 import com.eatssu.android.R
-import com.eatssu.android.data.remote.dto.request.ReportRequest
 import com.eatssu.android.domain.usecase.review.PostReportUseCase
 import com.eatssu.android.test.AppBehaviorSpec
 import com.eatssu.android.test.asStringResIdOrNull
@@ -20,7 +19,7 @@ class ReportViewModelBehaviorSpec : AppBehaviorSpec({
         val postReportUseCase = mockk<PostReportUseCase>()
 
         `when`("신고가 실패하면") {
-            coEvery { postReportUseCase(any()) } returns false
+            coEvery { postReportUseCase(any(), any(), any()) } returns false
             val viewModel = ReportViewModel(postReportUseCase)
 
             then("error=true와 실패 토스트를 설정한다") {
@@ -33,13 +32,13 @@ class ReportViewModelBehaviorSpec : AppBehaviorSpec({
                     viewModel.uiState.value.toastMessage.asStringResIdOrNull() shouldBe R.string.toast_report_failed
                     viewModel.uiState.value.isDone shouldBe false
 
-                    coVerify { postReportUseCase(ReportRequest(1L, "COPY", "bad")) }
+                    coVerify { postReportUseCase(1L, "COPY", "bad") }
                 }
             }
         }
 
         `when`("신고가 성공하면") {
-            coEvery { postReportUseCase(any()) } returns true
+            coEvery { postReportUseCase(any(), any(), any()) } returns true
             val viewModel = ReportViewModel(postReportUseCase)
 
             then("isDone=true와 성공 토스트를 설정한다") {

--- a/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/report/ReportViewModelBehaviorSpec.kt
@@ -32,7 +32,7 @@ class ReportViewModelBehaviorSpec : AppBehaviorSpec({
                     viewModel.uiState.value.toastMessage.asStringResIdOrNull() shouldBe R.string.toast_report_failed
                     viewModel.uiState.value.isDone shouldBe false
 
-                    coVerify { postReportUseCase(1L, "COPY", "bad") }
+                    coVerify { postReportUseCase(reviewId = 1L, reportType = "COPY", content = "bad") }
                 }
             }
         }


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
domain 레이어에서 가지는 request dto 의존성을 제거합니다.

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
DTO가 아닌 낱알의 필드(nickname, token)등으로 전달하도록 수정했습니다. 
필드가 많지 않은 경우에는 별도의 도메인 모델을 생성하지 않고 낱알의 필드로 전달하는 것이 좋을 것 같다고 판단했습니다.

다행히 많이 수정이 되어있어서, 작업사항이 많지는 않습니다. 

- [토큰 유효성 검사 API 관련](https://github.com/EAT-SSU/Android/commit/3f3a098f21c0b5872acf2ee711ccd21d2c90afe8)
- [신고하기 API 관련](https://github.com/EAT-SSU/Android/commit/777e708159e1cb26dfe5e628b321da7dae513186)
- [닉네임 변경 API 관련](https://github.com/EAT-SSU/Android/commit/63995338508ad1ca2d8f87ebbdaf3dd6e883b221)

## Issue

- Resolves #508

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

