### PR TITLE
[Feat] PostHog 이벤트 설계 반영

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -25,6 +25,8 @@ import com.eatssu.android.presentation.mypage.userinfo.UserInfoActivity
 import com.eatssu.android.presentation.util.showInfoToast
 import com.eatssu.android.presentation.util.showToast
 import com.eatssu.android.presentation.util.startActivity
+import com.eatssu.common.analytics.MapAnalyticsEvent
+import com.eatssu.common.analytics.MyPageAnalyticsEvent
 import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.enums.ScreenId
@@ -85,6 +87,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
                 }
 
                 R.id.map_menu -> {
+                    analyticsTracker.track(MapAnalyticsEvent.EntryClicked)
                     navController.navigate(R.id.mapFragment)
                     true
                 }
@@ -95,6 +98,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
                 }
 
                 R.id.mypage_menu -> {
+                    analyticsTracker.track(MyPageAnalyticsEvent.MenuClicked)
                     navController.navigate(R.id.myPageFragment)
                     true
                 }

--- a/app/src/main/java/com/eatssu/android/presentation/event/AnyoneButMeEventPopupController.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/event/AnyoneButMeEventPopupController.kt
@@ -8,8 +8,12 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.eatssu.android.R
 import com.eatssu.android.data.local.AppFeatureDataStore
+import com.eatssu.android.domain.usecase.user.GetUserCollegeDepartmentUseCase
 import com.eatssu.android.presentation.mypage.terms.WebViewActivity
 import com.eatssu.android.presentation.util.openInBrowser
+import com.eatssu.common.analytics.AnalyticsTracker
+import com.eatssu.common.analytics.AnyoneButMeAnalyticsEvent
+import com.eatssu.common.analytics.PopupAnalyticsEvent
 import com.eatssu.common.enums.ScreenId
 import com.eatssu.design_system.theme.EatssuTheme
 import dagger.hilt.android.qualifiers.ActivityContext
@@ -22,6 +26,8 @@ import javax.inject.Inject
 class AnyoneButMeEventPopupController @Inject constructor(
     @ActivityContext private val context: Context,
     private val appFeatureDataStore: AppFeatureDataStore,
+    private val getUserCollegeDepartmentUseCase: GetUserCollegeDepartmentUseCase,
+    private val analyticsTracker: AnalyticsTracker,
 ) {
     private lateinit var composeView: ComposeView
     private lateinit var lifecycleScope: LifecycleCoroutineScope
@@ -49,10 +55,10 @@ class AnyoneButMeEventPopupController @Inject constructor(
             EatssuTheme {
                 if (isPopupVisible.value) {
                     AnyoneButMeEventDialog(
-                        onDismiss = ::hide,
+                        onDismiss = ::closeByUser,
                         onDismissForever = ::dismissForever,
                         onInstagramClick = ::openInstagram,
-                        onAnyoneButMeClick = ::openAnyoneButMePage
+                        onAnyoneButMeClick = { openAnyoneButMePage(fromPopup = true) }
                     )
                 }
             }
@@ -71,13 +77,18 @@ class AnyoneButMeEventPopupController @Inject constructor(
     }
 
     private fun dismissForever() {
+        trackPopupAction(PopupAnalyticsEvent.Action.NOT_SHOW_AGAIN)
         hide()
         lifecycleScope.launch {
             appFeatureDataStore.setAnyoneButMeEventPopupDismissed(true)
         }
     }
 
-    fun openAnyoneButMePage() {
+    fun openAnyoneButMePage(fromPopup: Boolean = false) {
+        if (fromPopup) {
+            trackPopupAction(PopupAnalyticsEvent.Action.CLICK_POPUP_IMAGE)
+        }
+        trackAnyoneButMeClicked()
         hide()
         context.startActivity(
             Intent(context, WebViewActivity::class.java).apply {
@@ -93,8 +104,30 @@ class AnyoneButMeEventPopupController @Inject constructor(
     }
 
     private fun openInstagram() {
+        trackPopupAction(PopupAnalyticsEvent.Action.GO_INSTA)
         hide()
         context.openInBrowser(context.getString(R.string.eatssu_event_instagram_url))
+    }
+
+    private fun closeByUser() {
+        trackPopupAction(PopupAnalyticsEvent.Action.CLOSE)
+        hide()
+    }
+
+    private fun trackPopupAction(action: PopupAnalyticsEvent.Action) {
+        analyticsTracker.track(PopupAnalyticsEvent.AnyoneButMe(action))
+    }
+
+    private fun trackAnyoneButMeClicked() {
+        lifecycleScope.launch {
+            val userInfo = getUserCollegeDepartmentUseCase()
+            analyticsTracker.track(
+                AnyoneButMeAnalyticsEvent.Clicked(
+                    college = userInfo.userCollege.collegeId.toLong(),
+                    major = userInfo.userDepartment.departmentId.toLong(),
+                ),
+            )
+        }
     }
 
     private fun hide() {

--- a/app/src/main/java/com/eatssu/android/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/LoginActivity.kt
@@ -13,6 +13,7 @@ import com.eatssu.android.presentation.base.BaseActivity
 import com.eatssu.android.presentation.util.showErrorToast
 import com.eatssu.android.presentation.util.showToast
 import com.eatssu.android.presentation.util.startActivity
+import com.eatssu.common.analytics.LoginAnalyticsEvent
 import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.enums.ScreenId
@@ -52,6 +53,7 @@ class LoginActivity :
         }
 
         binding.ibKakaoLogin.setOnClickListener {
+            analyticsTracker.track(LoginAnalyticsEvent.Clicked(LoginAnalyticsEvent.Method.KAKAO))
             handleKakaoLogin()
         }
     }

--- a/app/src/main/java/com/eatssu/android/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/login/LoginViewModel.kt
@@ -8,6 +8,8 @@ import com.eatssu.android.domain.usecase.auth.LoginUseCase
 import com.eatssu.android.domain.usecase.auth.SetAccessTokenUseCase
 import com.eatssu.android.domain.usecase.auth.SetRefreshTokenUseCase
 import com.eatssu.android.domain.usecase.user.SetUserEmailUseCase
+import com.eatssu.common.analytics.AnalyticsTracker
+import com.eatssu.common.analytics.LoginAnalyticsEvent
 import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.UiText
@@ -30,6 +32,7 @@ class LoginViewModel @Inject constructor(
     private val setAccessTokenUseCase: SetAccessTokenUseCase,
     private val setRefreshTokenUseCase: SetRefreshTokenUseCase,
     private val setUserEmailUseCase: SetUserEmailUseCase,
+    private val analyticsTracker: AnalyticsTracker,
     private val analyticsIdentityManager: AnalyticsIdentityManager,
 ) : ViewModel() {
 
@@ -58,6 +61,7 @@ class LoginViewModel @Inject constructor(
             setRefreshTokenUseCase(token.refreshToken)
             setUserEmailUseCase(email)
             analyticsIdentityManager.identifyUser(email = email)
+            analyticsTracker.track(LoginAnalyticsEvent.Completed(LoginAnalyticsEvent.Method.KAKAO))
 
             _uiState.value = UiState.Success(LoginState.LoginSuccess)
         }

--- a/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
@@ -127,7 +127,6 @@ class MapViewModel @Inject constructor(
         when (filter) {
             FilterType.All -> {
                 loadPartnerships()
-                analyticsTracker.track(MapAnalyticsEvent.AllClicked)
             }
 
             FilterType.Mine -> {

--- a/app/src/main/java/com/eatssu/android/presentation/widget/MealWidgetReceiver.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/widget/MealWidgetReceiver.kt
@@ -3,6 +3,7 @@ package com.eatssu.android.presentation.widget
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import com.eatssu.android.domain.usecase.widget.LoadRestaurantByFileKeyUseCase
 import com.eatssu.android.presentation.widget.ui.MealWidget
 import com.eatssu.common.analytics.AnalyticsTracker
 import com.eatssu.common.analytics.WidgetAnalyticsEvent
@@ -16,6 +17,9 @@ import javax.inject.Inject
 class MealWidgetReceiver : GlanceAppWidgetReceiver() {
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
+
+    @Inject
+    lateinit var loadRestaurantByFileKeyUseCase: LoadRestaurantByFileKeyUseCase
 
     override val glanceAppWidget: GlanceAppWidget
         get() = MealWidget()
@@ -32,15 +36,17 @@ class MealWidgetReceiver : GlanceAppWidgetReceiver() {
     private fun cleanupWidgetDataStore(context: Context, appWidgetId: Int) {
         try {
             runBlocking {
+                val widgetFileKey = "appWidget-$appWidgetId"
                 val filename = "appWidgetLayout-${appWidgetId}"
                 val dataStoreFile = File(context.filesDir, "datastore/$filename")
+                val restaurant = loadRestaurantByFileKeyUseCase(widgetFileKey)
 
                 if (dataStoreFile.exists()) {
                     dataStoreFile.delete()
                     Timber.d("Deleted DataStore file for widget $appWidgetId")
                 }
 
-                analyticsTracker.track(WidgetAnalyticsEvent.Removed())
+                analyticsTracker.track(WidgetAnalyticsEvent.Removed(restaurant))
 
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/eatssu/android/presentation/widget/ui/WidgetSettingActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/widget/ui/WidgetSettingActivity.kt
@@ -16,9 +16,11 @@ import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.lifecycle.lifecycleScope
 import com.eatssu.android.analytics.ProvideAnalyticsTracker
+import com.eatssu.android.domain.usecase.widget.LoadRestaurantByFileKeyUseCase
 import com.eatssu.android.domain.usecase.widget.SaveRestaurantByFileKeyUseCase
 import com.eatssu.android.presentation.widget.MealWorker
 import com.eatssu.common.analytics.AnalyticsTracker
+import com.eatssu.common.analytics.WidgetAnalyticsEvent
 import com.eatssu.common.enums.Restaurant
 import com.eatssu.design_system.theme.EatssuTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -31,6 +33,9 @@ class WidgetSettingActivity : ComponentActivity() {
 
     @Inject
     lateinit var saveRestaurantByFileKeyUseCase: SaveRestaurantByFileKeyUseCase
+
+    @Inject
+    lateinit var loadRestaurantByFileKeyUseCase: LoadRestaurantByFileKeyUseCase
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
@@ -46,6 +51,7 @@ class WidgetSettingActivity : ComponentActivity() {
                     } // 변동 식당만 불러옵니다. 하드코딩 x
 
                     var selectedRestaurant by rememberSaveable { mutableStateOf(restaurantOptions[0]) }
+                    var previousRestaurant by remember { mutableStateOf<Restaurant?>(null) }
 
                     val appWidgetId = intent?.getIntExtra(
                         AppWidgetManager.EXTRA_APPWIDGET_ID,
@@ -54,11 +60,21 @@ class WidgetSettingActivity : ComponentActivity() {
                     var glanceId by remember { mutableStateOf<GlanceId?>(null) }
                     val context = LocalContext.current
                     LaunchedEffect(appWidgetId) {
-                        glanceId =
-                            if (appWidgetId != null && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
-                                GlanceAppWidgetManager(context).getGlanceIdBy(appWidgetId)
+                        glanceId = if (appWidgetId != null && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                            GlanceAppWidgetManager(context).getGlanceIdBy(appWidgetId)
                         } else {
                             null
+                        }
+
+                        previousRestaurant =
+                            if (appWidgetId != null && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                                loadRestaurantByFileKeyUseCase("appWidget-$appWidgetId")
+                            } else {
+                                null
+                            }
+
+                        previousRestaurant?.let { savedRestaurant ->
+                            selectedRestaurant = getString(savedRestaurant.displayNameResId)
                         }
                     }
 
@@ -75,11 +91,26 @@ class WidgetSettingActivity : ComponentActivity() {
                             }
 
                             lifecycleScope.launch {
+                                val widgetFileKey = "appWidget-$appWidgetId"
 
                                 saveRestaurantByFileKeyUseCase(
-                                    "appWidget-${appWidgetId}",
+                                    widgetFileKey,
                                     selectedRestaurantValue
                                 )
+
+                                when (val before = previousRestaurant) {
+                                    null -> analyticsTracker.track(WidgetAnalyticsEvent.Added(selectedRestaurantValue))
+                                    selectedRestaurantValue ->
+                                        Unit
+
+                                    else ->
+                                        analyticsTracker.track(
+                                            WidgetAnalyticsEvent.Changed(
+                                                restaurantBefore = before,
+                                                restaurantAfter = selectedRestaurantValue,
+                                            ),
+                                        )
+                                }
 
                                 // 위젯 업데이트
                                 glanceId?.let {
@@ -90,17 +121,16 @@ class WidgetSettingActivity : ComponentActivity() {
                                 MealWorker.enqueue(this@WidgetSettingActivity)
 
                                 Timber.d("선택하기 버튼으로 저장: $selectedRestaurantValue for glanceId: $glanceId")
-                            }
 
-                            // 결과 설정
-                            val resultIntent = Intent().apply {
-                                putExtra(
-                                    AppWidgetManager.EXTRA_APPWIDGET_ID,
-                                    appWidgetId ?: AppWidgetManager.INVALID_APPWIDGET_ID
-                                )
+                                val resultIntent = Intent().apply {
+                                    putExtra(
+                                        AppWidgetManager.EXTRA_APPWIDGET_ID,
+                                        appWidgetId ?: AppWidgetManager.INVALID_APPWIDGET_ID
+                                    )
+                                }
+                                setResult(RESULT_OK, resultIntent)
+                                finish()
                             }
-                            setResult(RESULT_OK, resultIntent)
-                            finish()
                         },
                         onBack = { finish() }
                     )

--- a/app/src/main/java/com/eatssu/android/presentation/widget/ui/WidgetSettingScreen.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/widget/ui/WidgetSettingScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.eatssu.android.R
-import com.eatssu.android.analytics.LocalAnalyticsTracker
-import com.eatssu.common.analytics.WidgetAnalyticsEvent
 import com.eatssu.android.presentation.util.asString
 import com.eatssu.common.enums.Restaurant
 import com.eatssu.design_system.component.EatSsuButton
@@ -34,8 +32,6 @@ fun WidgetSettingScreen(
     onConfirm: (Restaurant) -> Unit = {},
     onBack: () -> Unit = {}  // 뒤로가기 동작을 위한 람다 추가
 ) {
-    val analyticsTracker = LocalAnalyticsTracker.current
-
     // onClick 람다에서 LocalContext 접근이 불가하므로 Composable 레벨에서 미리 매핑 생성
     val restaurantDisplayNameMap = Restaurant.getVariableRestaurantList()
         .associateBy { it.toUiText().asString() }
@@ -77,7 +73,6 @@ fun WidgetSettingScreen(
                             ?: Restaurant.HAKSIK
 
                         onConfirm(selectedRestaurantEnum)
-                        analyticsTracker.track(WidgetAnalyticsEvent.Added(selectedRestaurantEnum))
                     }
                 )
             }

--- a/app/src/test/java/com/eatssu/android/analytics/DefaultAnalyticsTrackerTest.kt
+++ b/app/src/test/java/com/eatssu/android/analytics/DefaultAnalyticsTrackerTest.kt
@@ -30,7 +30,7 @@ class DefaultAnalyticsTrackerTest {
         val second = FakeAnalyticsTracker(id = "duplicate")
         val analyticsTracker = DefaultAnalyticsTracker(setOf(first, second))
 
-        analyticsTracker.track(MapAnalyticsEvent.AllClicked)
+        analyticsTracker.track(MapAnalyticsEvent.EntryClicked)
 
         assertEquals(1, first.events.size + second.events.size)
     }
@@ -57,7 +57,7 @@ class DefaultAnalyticsTrackerTest {
         val failingTracker = FakeAnalyticsTracker(id = "firebase", failOnTrack = true)
         val healthyTracker = FakeAnalyticsTracker(id = "posthog")
         val analyticsTracker = DefaultAnalyticsTracker(setOf(failingTracker, healthyTracker))
-        val event = MapAnalyticsEvent.AllClicked
+        val event = MapAnalyticsEvent.EntryClicked
 
         analyticsTracker.track(event)
 

--- a/app/src/test/java/com/eatssu/android/analytics/FirebaseAnalyticsTrackerTest.kt
+++ b/app/src/test/java/com/eatssu/android/analytics/FirebaseAnalyticsTrackerTest.kt
@@ -38,7 +38,7 @@ class FirebaseAnalyticsTrackerTest {
             mapOf(
                 "rating" to 5L,
                 "likes" to 2L,
-                "photo_attached" to true,
+                "photo_attached" to 1L,
             ),
             payload.properties,
         )

--- a/app/src/test/java/com/eatssu/android/analytics/PostHogAnalyticsTrackerTest.kt
+++ b/app/src/test/java/com/eatssu/android/analytics/PostHogAnalyticsTrackerTest.kt
@@ -2,6 +2,7 @@ package com.eatssu.android.analytics
 
 import com.eatssu.common.analytics.AnalyticsIdentity
 import com.eatssu.common.analytics.AppAnalyticsEvent
+import com.eatssu.common.analytics.LoginAnalyticsEvent
 import com.eatssu.common.analytics.WidgetAnalyticsEvent
 import com.eatssu.common.enums.LaunchPath
 import com.eatssu.common.enums.Restaurant
@@ -17,6 +18,14 @@ class PostHogAnalyticsTrackerTest {
 
         assertEquals("app_launch", payload.eventName)
         assertEquals(mapOf("launch_path" to "widget"), payload.properties)
+    }
+
+    @Test
+    fun `remote notification launch payload keeps distinct path`() {
+        val payload = AppAnalyticsEvent.Launch(LaunchPath.REMOTE_NOTIFICATION).toPayload()
+
+        assertEquals("app_launch", payload.eventName)
+        assertEquals(mapOf("launch_path" to "remote_notification"), payload.properties)
     }
 
     @Test
@@ -56,5 +65,30 @@ class PostHogAnalyticsTrackerTest {
 
         assertEquals("add_widget", payload.eventName)
         assertEquals(mapOf("restaurants" to "haksik"), payload.properties)
+    }
+
+    @Test
+    fun `widget change payload keeps before and after keys`() {
+        val payload = WidgetAnalyticsEvent.Changed(
+            restaurantBefore = Restaurant.DODAM,
+            restaurantAfter = Restaurant.HAKSIK,
+        ).toPayload()
+
+        assertEquals("change_widget", payload.eventName)
+        assertEquals(
+            mapOf(
+                "restaurant_before" to "dodam",
+                "restaurant_after" to "haksik",
+            ),
+            payload.properties,
+        )
+    }
+
+    @Test
+    fun `login payload keeps method schema`() {
+        val payload = LoginAnalyticsEvent.Clicked(LoginAnalyticsEvent.Method.KAKAO).toPayload()
+
+        assertEquals("click_login", payload.eventName)
+        assertEquals(mapOf("method" to "kakao"), payload.properties)
     }
 }

--- a/app/src/test/java/com/eatssu/android/presentation/login/LoginViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/login/LoginViewModelBehaviorSpec.kt
@@ -11,6 +11,8 @@ import com.eatssu.android.test.AppBehaviorSpec
 import com.eatssu.android.test.assertToast
 import com.eatssu.android.test.awaitToastEvent
 import com.eatssu.android.test.sampleToken
+import com.eatssu.common.analytics.AnalyticsTracker
+import com.eatssu.common.analytics.LoginAnalyticsEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.enums.DeviceType
 import com.eatssu.common.enums.ToastType
@@ -36,6 +38,7 @@ class LoginViewModelBehaviorSpec : AppBehaviorSpec({
         val setAccessTokenUseCase = mockk<SetAccessTokenUseCase>()
         val setRefreshTokenUseCase = mockk<SetRefreshTokenUseCase>()
         val setUserEmailUseCase = mockk<SetUserEmailUseCase>()
+        val analyticsTracker = mockk<AnalyticsTracker>(relaxed = true)
         val analyticsIdentityManager = mockk<AnalyticsIdentityManager>(relaxed = true)
 
         every { setAccessTokenUseCase(any()) } just Runs
@@ -48,6 +51,7 @@ class LoginViewModelBehaviorSpec : AppBehaviorSpec({
                 setAccessTokenUseCase = setAccessTokenUseCase,
                 setRefreshTokenUseCase = setRefreshTokenUseCase,
                 setUserEmailUseCase = setUserEmailUseCase,
+                analyticsTracker = analyticsTracker,
                 analyticsIdentityManager = analyticsIdentityManager,
             )
             coEvery { loginUseCase("a@b.com", "pid", DeviceType.ANDROID) } returns null
@@ -72,6 +76,7 @@ class LoginViewModelBehaviorSpec : AppBehaviorSpec({
                 setAccessTokenUseCase = setAccessTokenUseCase,
                 setRefreshTokenUseCase = setRefreshTokenUseCase,
                 setUserEmailUseCase = setUserEmailUseCase,
+                analyticsTracker = analyticsTracker,
                 analyticsIdentityManager = analyticsIdentityManager,
             )
             val token = sampleToken("acc", "ref")
@@ -86,6 +91,11 @@ class LoginViewModelBehaviorSpec : AppBehaviorSpec({
                         verify { setRefreshTokenUseCase("ref") }
                         coVerify { setUserEmailUseCase("a@b.com") }
                         verify { analyticsIdentityManager.identifyUser(email = "a@b.com") }
+                        verify {
+                            analyticsTracker.track(
+                                LoginAnalyticsEvent.Completed(LoginAnalyticsEvent.Method.KAKAO),
+                            )
+                        }
                         viewModel.uiState.value shouldBe UiState.Success(LoginState.LoginSuccess)
                     }
                 }
@@ -99,6 +109,7 @@ class LoginViewModelBehaviorSpec : AppBehaviorSpec({
             setAccessTokenUseCase = mockk(relaxed = true),
             setRefreshTokenUseCase = mockk(relaxed = true),
             setUserEmailUseCase = mockk(relaxed = true),
+            analyticsTracker = mockk(relaxed = true),
             analyticsIdentityManager = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
@@ -127,7 +127,7 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                 analyticsTracker = analyticsTracker,
             )
 
-            then("필터에 맞는 목록을 로드하고 이벤트 로깅을 수행한다") {
+            then("필터에 맞는 목록을 로드하고 Mine 필터 이벤트를 로깅한다") {
                 runTest {
                     eventually(2.seconds) {
                         val initial = viewModel.uiState.value as UiState.Success
@@ -141,7 +141,6 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                         allState.data.selectedFilter shouldBe FilterType.All
                         allState.data.partnerships shouldBe allPartnerships
                     }
-                    verify(atLeast = 1) { analyticsTracker.track(MapAnalyticsEvent.AllClicked) }
 
                     viewModel.setFilter(FilterType.Mine)
                     eventually(2.seconds) {

--- a/core/common/src/main/java/com/eatssu/common/analytics/AnalyticsEvent.kt
+++ b/core/common/src/main/java/com/eatssu/common/analytics/AnalyticsEvent.kt
@@ -26,6 +26,32 @@ sealed interface AppAnalyticsEvent : AnalyticsEvent {
     }
 }
 
+sealed interface LoginAnalyticsEvent : AnalyticsEvent {
+    enum class Method(val value: String) {
+        KAKAO("kakao"),
+        APPLE("apple"),
+        GUEST("guest"),
+    }
+
+    data class Clicked(
+        val method: Method,
+    ) : LoginAnalyticsEvent {
+        override val eventName = "click_login"
+        override val properties = buildMap {
+            put("method", method.value)
+        }
+    }
+
+    data class Completed(
+        val method: Method,
+    ) : LoginAnalyticsEvent {
+        override val eventName = "complete_login"
+        override val properties = buildMap {
+            put("method", method.value)
+        }
+    }
+}
+
 sealed interface CafeteriaAnalyticsEvent : AnalyticsEvent {
     data class RestaurantInfoClicked(
         val restaurant: Restaurant,
@@ -48,7 +74,7 @@ sealed interface CafeteriaAnalyticsEvent : AnalyticsEvent {
     data class DaySelected(
         val day: String,
     ) : CafeteriaAnalyticsEvent {
-        override val eventName = "click_day"
+        override val eventName = "select_day"
         override val properties = buildMap {
             put("day", day.toWeekdayCode())
         }
@@ -79,13 +105,13 @@ sealed interface ReviewAnalyticsEvent : AnalyticsEvent {
         override val properties = buildMap {
             put("rating", rating)
             put("likes", likes)
-            put("photo_attached", photoAttached)
+            put("photo_attached", if (photoAttached) 1L else 0L)
         }
     }
 }
 
 sealed interface MapAnalyticsEvent : AnalyticsEvent {
-    object AllClicked : MapAnalyticsEvent {
+    object EntryClicked : MapAnalyticsEvent {
         override val eventName = "click_map"
         override val properties = emptyMap<String, Any>()
     }
@@ -115,6 +141,45 @@ sealed interface MapAnalyticsEvent : AnalyticsEvent {
     }
 }
 
+sealed interface AnyoneButMeAnalyticsEvent : AnalyticsEvent {
+    data class Clicked(
+        val college: Long,
+        val major: Long,
+    ) : AnyoneButMeAnalyticsEvent {
+        override val eventName = "click_plz_not_me"
+        override val properties = buildMap {
+            put("college", college)
+            put("major", major)
+        }
+    }
+}
+
+sealed interface MyPageAnalyticsEvent : AnalyticsEvent {
+    object MenuClicked : MyPageAnalyticsEvent {
+        override val eventName = "click_mypage_menu"
+        override val properties = emptyMap<String, Any>()
+    }
+}
+
+sealed interface PopupAnalyticsEvent : AnalyticsEvent {
+    enum class Action(val value: String) {
+        CLICK_POPUP_IMAGE("click_popup_image"),
+        GO_INSTA("go_insta"),
+        NOT_SHOW_AGAIN("not_show_again"),
+        CLOSE("close"),
+    }
+
+    data class AnyoneButMe(
+        val action: Action,
+    ) : PopupAnalyticsEvent {
+        override val eventName = "popup_event"
+        override val properties = buildMap {
+            put("popup_name", "plz_not_me")
+            put("popup_action", action.value)
+        }
+    }
+}
+
 sealed interface WidgetAnalyticsEvent : AnalyticsEvent {
     data class Added(
         val restaurant: Restaurant,
@@ -135,11 +200,13 @@ sealed interface WidgetAnalyticsEvent : AnalyticsEvent {
     }
 
     data class Changed(
-        val restaurant: Restaurant,
+        val restaurantBefore: Restaurant,
+        val restaurantAfter: Restaurant,
     ) : WidgetAnalyticsEvent {
         override val eventName = "change_widget"
         override val properties = buildMap {
-            put("restaurants", restaurant.value)
+            put("restaurant_before", restaurantBefore.value)
+            put("restaurant_after", restaurantAfter.value)
         }
     }
 }

--- a/core/common/src/test/java/com/eatssu/common/enums/EnumsBehaviorSpec.kt
+++ b/core/common/src/test/java/com/eatssu/common/enums/EnumsBehaviorSpec.kt
@@ -55,6 +55,12 @@ class EnumsBehaviorSpec : BehaviorSpec({
                 )
             }
         }
+
+        `when`("analytics value를 확인하면") {
+            then("기숙사 식당은 설계 문서 기준 값으로 노출된다") {
+                Restaurant.DORMITORY.value shouldBe "dormitory"
+            }
+        }
     }
 
     given("ReportType") {


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
PostHog 이벤트 설계 문서와 현재 Android 앱의 실제 트래킹 코드 사이에 있던 불일치를 정리했습니다.

이번 PR은 특히 아래 3가지를 맞추는 데 집중했습니다.
- 문서에는 있지만 앱에서 누락되어 있던 이벤트 추가
- 기존 이벤트의 호출 지점이 설계 의미와 다르게 연결되어 있던 부분 수정
- 동일 이벤트라도 payload 스키마와 값 타입이 다르던 부분 정리

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
### 1. 새로 추가한 이벤트

| 이벤트 | 기존 | 변경 후 | 추가한 이유 |
|--|--|--|--|
| `click_login` | 미수집 | 카카오 로그인 버튼 클릭 시 수집 | 문서상 정의되어 있으나 Android 미구현 |
| `complete_login` | 미수집 | 로그인 성공 후 토큰 저장 완료 시 수집 | 로그인 성공 전환 추적 필요 |
| `click_mypage_menu` | 미수집 | 하단 `마이페이지` 탭 클릭 시 수집 | 문서상 정의되어 있으나 Android 미구현 |
| `popup_event` | 미수집 | 나만아니면돼 팝업 액션별 수집 | 팝업 액션 분석 필요 |
| `click_plz_not_me` | 미수집 | 나만아니면돼 페이지 진입 시 수집 | 문서상 정의되어 있으나 Android 미구현 |

### 2. 기존 이벤트 호출 지점 변경

| 이벤트 | 기존 호출 지점 | 새 호출 지점 | 변경 이유 |
|--|--|--|--|
| `click_map` | 지도 화면 내부 `전체` 필터 클릭 (`MapViewModel`) | 하단 탭에서 지도 진입 (`MainActivity`) | 이벤트 의미를 `제휴지도 클릭`에 맞춤 |
| `select_day` | `click_day` 이름으로 동일 UI 액션에서 수집 | 메뉴 화면에서 요일 변경 시 `select_day`로 수집 | 이벤트명 정합성 반영 |
| `change_widget` | 위젯 설정 화면에서 사실상 수집되지 않음. 기존 확인 버튼은 항상 `add_widget`만 수집 | 기존 위젯 설정 변경 시 `change_widget` 수집 | 추가/변경 이벤트를 분리 |
| `remove_widget` | 위젯 삭제 시 payload 없이 수집 | 가능하면 삭제된 식당값을 포함해 수집 | 문서의 `restaurants` 파라미터 반영 |

### 3. payload 스키마 / 값 차이 정리

| 이벤트 | 필드 | 기존 값 | 새 값 |
|--|--|--|--|
| `complete_review_v2` | `photo_attached` | `true` / `false` | `1` / `0` |
| `change_widget` | payload | `restaurants=<after>` | `restaurant_before`, `restaurant_after` |
| `select_day` | event name | `click_day` | `select_day` |
| `app_launch` | `launch_path` | `icon`, `widget`, `local_notification`, `remote_notification` | 동일 유지 |
| `popup_event` | `popup_action` | 미수집 | `click_popup_image`, `go_insta`, `not_show_again`, `close` |

### 4. 기존 로직과 새 로직의 트래킹 값 차이

#### 로그인
- 기존: 로그인 관련 커스텀 이벤트 없음
- 변경 후:
  - 버튼 클릭 시 `click_login(method=kakao)`
  - 성공 시 `complete_login(method=kakao)`

#### 지도
- 기존: `click_map`가 `전체` 필터 클릭에 기록됨
- 변경 후: `click_map`는 지도 탭 진입에만 기록됨
- 기존 `내 제휴` 클릭은 그대로 `click_map_mine(college, major)` 유지

#### 리뷰 작성 완료
- 기존: `complete_review_v2(photo_attached=true/false)`
- 변경 후: `complete_review_v2(photo_attached=1/0)`

#### 위젯
- 기존:
  - 확인 버튼 클릭 시 항상 `add_widget(restaurants=<selected>)`
  - 위젯 변경과 최초 추가를 구분하지 못함
  - 삭제 시 `remove_widget()`로 payload 없음
- 변경 후:
  - 최초 설정: `add_widget(restaurants=<selected>)`
  - 기존 위젯 식당 변경: `change_widget(restaurant_before, restaurant_after)`
  - 같은 식당 재선택: 이벤트 미전송
  - 삭제 시 가능하면 `remove_widget(restaurants=<selected>)`

#### 나만아니면돼 팝업
- 기존: 팝업 관련 커스텀 이벤트 없음
- 변경 후:
  - 팝업 이미지 클릭: `popup_event(popup_name=plz_not_me, popup_action=click_popup_image)`
  - 인스타 이동: `popup_event(..., popup_action=go_insta)`
  - 다시 보지 않기: `popup_event(..., popup_action=not_show_again)`
  - 닫기: `popup_event(..., popup_action=close)`
  - 페이지 진입: `click_plz_not_me(college, major)`

### 5. 테스트 보강
- analytics payload 테스트 추가 및 수정
- login 성공 이벤트 테스트 추가
- map 이벤트 의미 변경 반영 테스트 수정
- enum 값 검증 테스트 보강
