### PR TITLE
[Feat] 나만아니면돼 가리기

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -44,6 +44,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
     ActivityMainBinding::inflate,
     ScreenId.HOME_MAIN
 ) {
+    companion object {
+        private const val ENABLE_ANYONE_BUT_ME_POPUP = false
+    }
 
     @Inject
     lateinit var workManager: WorkManager
@@ -63,7 +66,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
 
         setupNoToolbar()
         setNavigation()
-        bindEventPopup(showOnLaunch = savedInstanceState == null)
+        bindEventPopup(showOnLaunch = ENABLE_ANYONE_BUT_ME_POPUP && savedInstanceState == null)
         bindEventTooltip()
 
         checkAlarmPermission()

--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -45,8 +45,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
     ScreenId.HOME_MAIN
 ) {
     companion object {
-        private const val ENABLE_ANYONE_BUT_ME_POPUP = false
-        private const val ENABLE_ANYONE_BUT_ME_TOOLTIP = false
+        private const val ENABLE_ANYONE_BUT_ME = false
     }
 
     @Inject
@@ -67,8 +66,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
 
         setupNoToolbar()
         setNavigation()
-        bindEventPopup(showOnLaunch = ENABLE_ANYONE_BUT_ME_POPUP && savedInstanceState == null)
-        if (ENABLE_ANYONE_BUT_ME_TOOLTIP) {
+        if (ENABLE_ANYONE_BUT_ME) {
+            bindEventPopup(showOnLaunch = savedInstanceState == null)
             bindEventTooltip()
         }
 

--- a/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/MainActivity.kt
@@ -46,6 +46,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
 ) {
     companion object {
         private const val ENABLE_ANYONE_BUT_ME_POPUP = false
+        private const val ENABLE_ANYONE_BUT_ME_TOOLTIP = false
     }
 
     @Inject
@@ -67,7 +68,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
         setupNoToolbar()
         setNavigation()
         bindEventPopup(showOnLaunch = ENABLE_ANYONE_BUT_ME_POPUP && savedInstanceState == null)
-        bindEventTooltip()
+        if (ENABLE_ANYONE_BUT_ME_TOOLTIP) {
+            bindEventTooltip()
+        }
 
         checkAlarmPermission()
         collectState()


### PR DESCRIPTION
## Summary
나만아니면돼 팝업과 바텀 네비게이션 툴팁이 자동으로 노출되지 않도록 가립니다.
레이아웃 파일과 관련 구현은 유지하고, 표시 여부만 단일 플래그로 제어합니다.

## Describe your changes
- `MainActivity`에 `ENABLE_ANYONE_BUT_ME` 플래그를 추가했습니다.
- `ENABLE_ANYONE_BUT_ME`가 `true`일 때만 `bindEventPopup(showOnLaunch = savedInstanceState == null)`과 `bindEventTooltip()`가 실행되도록 변경했습니다.
- 플래그가 `false`이면 팝업과 툴팁이 모두 바인딩되지 않아 자동 노출되지 않습니다.
- `activity_main.xml`과 팝업/툴팁 Compose 구현은 그대로 유지했습니다.

## Testing
- `./gradlew :app:compileDebugKotlin`

## To reviewers
- 하단 `나만아니면돼` 탭 진입 동작은 그대로 유지됩니다.
- 추후 다시 노출이 필요하면 `ENABLE_ANYONE_BUT_ME`만 `true`로 변경하면 됩니다.