### PR TITLE
release: 3.2.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 61
-        versionName = "3.2.8"
+        versionCode = 62
+        versionName = "3.2.9"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.9.yml
+++ b/release-notes/v3.2.9.yml
@@ -1,0 +1,6 @@
+ko: |
+  - 원하지 않는 나만아니면돼 메뉴를 목록에서 숨길 수 있게 되었어요.
+  - 앱의 안정성과 사용성을 높이기 위해 내부 구조를 개선했어요.
+en: |
+  - You can now hide menus you do not want to see in the Not Me menu list.
+  - We improved internal app structure to provide better stability and usability.


### PR DESCRIPTION
## Release 3.2.9

### 변경사항 (3.2.8 → 3.2.9)

| 커밋 | 설명 | PR |
|------|------|----|
| `07bc4661` | [Feat] 나만아니면돼 가리기 | #514 |
| `144987c9` | [Refactor] domain 레이어에서 가지는 request dto 의존성을 제거합니다. | #512 |

### 릴리즈 노트 (Play Store)

**한국어**
- 원하지 않는 나만아니면돼 메뉴를 목록에서 숨길 수 있게 되었어요.
- 앱의 안정성과 사용성을 높이기 위해 내부 구조를 개선했어요.

**English**
- You can now hide menus you do not want to see in the Not Me menu list.
- We improved internal app structure to provide better stability and usability.

### 버전 정보
- `versionCode`: 61 → 62
- `versionName`: 3.2.8 → 3.2.9