### PR TITLE
release: 3.2.10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 62
-        versionName = "3.2.9"
+        versionCode = 63
+        versionName = "3.2.10"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.10.yml
+++ b/release-notes/v3.2.10.yml
@@ -1,0 +1,4 @@
+ko: |
+  - 시작 화면과 앱 아이콘이 새 계절 테마에 맞춰 자연스럽게 바뀌어요.
+en: |
+  - The splash screen and app icon now update smoothly to match the new seasonal theme.


### PR DESCRIPTION
## Release 3.2.10

### 변경사항 (3.2.9 → 3.2.10)

| 커밋 | 설명 | PR |
|------|------|----|
| `4a391f6e` | Remote Config 기반 앱 테마 전환 추가 | #516 |

### 릴리즈 노트 (Play Store)

**한국어**
- 시작 화면과 앱 아이콘이 새 계절 테마에 맞춰 자연스럽게 바뀌어요.

**English**
- The splash screen and app icon now update smoothly to match the new seasonal theme.

### 버전 정보
- `versionCode`: 62 → 63
- `versionName`: 3.2.9 → 3.2.10