### PR TITLE
[Feat] 마이페이지 디자인 반영 및 Compose 전환

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -153,6 +153,9 @@
             android:name=".presentation.mypage.language.LanguageSelectorActivity"
             android:exported="false" />
         <activity
+            android:name=".presentation.mypage.terms.TermSelectorActivity"
+            android:exported="false" />
+        <activity
                 android:name=".presentation.intro.IntroActivity"
             android:exported="true">
             <!-- 딥링크 필터  -->

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
@@ -3,36 +3,48 @@ package com.eatssu.android.presentation.mypage
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Paint
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.eatssu.android.R
-import com.eatssu.android.databinding.FragmentMyPageBinding
+import com.eatssu.android.analytics.ProvideAnalyticsTracker
+import com.eatssu.android.presentation.MainState
 import com.eatssu.android.presentation.MainViewModel
-import com.eatssu.android.presentation.base.BaseFragment
 import com.eatssu.android.presentation.login.LoginActivity
+import com.eatssu.android.presentation.mypage.language.LanguageSelectorActivity
 import com.eatssu.android.presentation.mypage.myreview.MyReviewListComposeActivity
+import com.eatssu.android.presentation.mypage.terms.TermSelectorActivity
 import com.eatssu.android.presentation.mypage.terms.WebViewActivity
 import com.eatssu.android.presentation.mypage.userinfo.UserInfoActivity
-import com.eatssu.android.presentation.mypage.language.LanguageSelectorActivity
 import com.eatssu.android.presentation.util.showDialog
 import com.eatssu.android.presentation.util.showErrorToast
 import com.eatssu.android.presentation.util.showInfoToast
 import com.eatssu.android.presentation.util.showToast
 import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
+import com.eatssu.common.analytics.AnalyticsTracker
 import com.eatssu.common.analytics.ScreenViewEvent
 import com.eatssu.common.enums.ScreenId
+import com.eatssu.design_system.theme.EatssuTheme
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.kakao.sdk.common.util.KakaoCustomTabsClient
 import com.kakao.sdk.talk.TalkApiClient
@@ -42,48 +54,132 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN) {
+class MyPageFragment : Fragment() {
+
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
 
     private val myPageViewModel: MyPageViewModel by viewModels()
-    private val mainViewModel: MainViewModel by activityViewModels<MainViewModel>()
+    private val mainViewModel: MainViewModel by activityViewModels()
+    private var lastNotificationPermissionState: Boolean? = null
 
-    override fun setBinding(layoutInflater: LayoutInflater): FragmentMyPageBinding {
-        return FragmentMyPageBinding.inflate(layoutInflater)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val uiState by myPageViewModel.uiState.collectAsStateWithLifecycle()
+                val mainUiState by mainViewModel.uiState.collectAsStateWithLifecycle()
+
+                val departmentName = when (val state = mainUiState) {
+                    is UiState.Success -> {
+                        when (val data = state.data) {
+                            is MainState.DepartmentState -> data.departmentName
+                                ?: stringResource(R.string.not_found)
+
+                            else -> stringResource(R.string.widget_loading)
+                        }
+                    }
+
+                    else -> stringResource(R.string.widget_loading)
+                }
+
+                ProvideAnalyticsTracker(analyticsTracker) {
+                    EatssuTheme {
+                        when (val state = uiState) {
+                            is UiState.Success -> {
+                                MyPageScreen(
+                                    state = state.data,
+                                    departmentName = departmentName,
+                                    onAlarmToggle = ::handleAlarmSwitchChange,
+                                    onMyInfoClick = {
+                                        startActivity(
+                                            Intent(
+                                                requireContext(),
+                                                UserInfoActivity::class.java
+                                            )
+                                        )
+                                    },
+                                    onMyReviewClick = {
+                                        startActivity(
+                                            Intent(
+                                                requireContext(),
+                                                MyReviewListComposeActivity::class.java
+                                            )
+                                        )
+                                    },
+                                    onInquireClick = ::openInquire,
+                                    onInstagramClick = {
+                                        startWebView(
+                                            getString(R.string.eatssu_instagram_url),
+                                            getString(R.string.eatssu_instagram),
+                                            ScreenId.EXTERNAL_TERMS
+                                        )
+                                    },
+                                    onLanguageSettingClick = {
+                                        startActivity(
+                                            Intent(
+                                                requireContext(),
+                                                LanguageSelectorActivity::class.java
+                                            )
+                                        )
+                                    },
+                                    onTermRulesClick = {
+                                        startActivity(
+                                            Intent(
+                                                requireContext(),
+                                                TermSelectorActivity::class.java
+                                            )
+                                        )
+                                    },
+                                    onDeveloperClick = {
+                                        startActivity(
+                                            Intent(
+                                                requireContext(),
+                                                DeveloperActivity::class.java
+                                            )
+                                        )
+                                    },
+                                    onOssClick = ::moveToOss,
+                                    onLogoutClick = ::showLogoutDialog,
+                                    onAppVersionClick = ::moveToPlayStore,
+                                    onSignOutClick = ::openSignOut,
+                                )
+                            }
+
+                            UiState.Init, UiState.Loading, UiState.Error -> {
+                                Box(modifier = Modifier.fillMaxSize())
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        binding.tvSignout.paintFlags = Paint.UNDERLINE_TEXT_FLAG
+        lastNotificationPermissionState = checkNotificationPermission(requireContext())
         setupObservers()
-        setOnClickListener()
     }
 
     override fun onResume() {
         super.onResume()
-        myPageViewModel.fetchMyInfo() // 닉네임 변경 등으로부터 복귀 시 정보 갱신
-        checkNotificationPermissionChange() // 설정 화면에서 돌아왔을 때 권한 상태 확인
+        analyticsTracker.track(ScreenViewEvent(ScreenId.MYPAGE_MAIN))
+        Timber.d("screen view logging: ${ScreenId.MYPAGE_MAIN}")
+        myPageViewModel.fetchMyInfo()
+        checkNotificationPermissionChange()
     }
 
     private fun setupObservers() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    myPageViewModel.uiState.collectLatest { ui ->
-                        when (ui) {
-                            is UiState.Init, UiState.Loading -> Unit // 닉네임만 불러옴으로 로딩 인디케이터 없음
-                            is UiState.Success -> {
-                                render(ui.data)
-                            }
-
-                            is UiState.Error -> {
-                                showErrorToast(R.string.not_found)
-                            }
-                        }
-                    }
-                }
                 launch {
                     myPageViewModel.uiEvent.collectLatest { event ->
                         when (event) {
@@ -95,104 +191,34 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
         }
     }
 
-    private fun render(state: MyPageState) {
-        // 앱 버전
-        binding.tvAppVersion.text = state.appVersion
-
-        // 닉네임
-        if (state.hasNickname) {
-            binding.tvNickname.text = state.nickname
-        } else {
-            // 필요 시 미설정 안내 문구
-            binding.tvNickname.text = getString(R.string.set_nickname)
-        }
-
-        // 초기 권한 상태 저장 (처음 로드될 때만)
-        if (lastNotificationPermissionState == null) {
-            lastNotificationPermissionState = checkNotificationPermission(requireContext())
-        }
-
-        // 알람 스위치 (리스너 잠시 해제 후 값 반영)
-        binding.alarmSwitch.setOnCheckedChangeListener(null)
-        binding.alarmSwitch.isChecked = state.isAlarmOn
-        binding.alarmSwitch.setOnCheckedChangeListener { _, isChecked ->
-            handleAlarmSwitchChange(isChecked)
-        }
-    }
-
     private fun handleAlarmSwitchChange(isChecked: Boolean) {
         if (isChecked) {
             if (checkNotificationPermission(requireContext())) {
                 myPageViewModel.setNotificationOn()
             } else {
                 showNotificationPermissionDialog()
-                // 권한 미허용이면 스위치 원복
-                binding.alarmSwitch.setOnCheckedChangeListener(null)
-                binding.alarmSwitch.isChecked = false
-                binding.alarmSwitch.setOnCheckedChangeListener { _, checked ->
-                    handleAlarmSwitchChange(checked)
-                }
             }
         } else {
             myPageViewModel.setNotificationOff()
         }
     }
 
-    private fun setOnClickListener() {
-        binding.llMyInfo.setOnClickListener {
-            startActivity(Intent(requireContext(), UserInfoActivity::class.java))
+    private fun openInquire() {
+        val context = requireContext()
+        val channelPublicId = "_ZlVAn"
+
+        TalkApiClient.instance.chatChannel(context, channelPublicId) {
+            val url = TalkApiClient.instance.chatChannelUrl(channelPublicId)
+            KakaoCustomTabsClient.openWithDefault(context, url)
         }
+        analyticsTracker.track(ScreenViewEvent(ScreenId.EXTERNAL_INQUIRE))
+    }
 
-        binding.llInquire.setOnClickListener {
-            val context = requireContext()
-            val channelPublicId = "_ZlVAn"
-
-            TalkApiClient.instance.chatChannel(context, channelPublicId) {
-                val url = TalkApiClient.instance.chatChannelUrl(channelPublicId)
-                KakaoCustomTabsClient.openWithDefault(context, url)
-            }
-            analyticsTracker.track(ScreenViewEvent(ScreenId.EXTERNAL_INQUIRE))
-        }
-
-        binding.llMyReview.setOnClickListener {
-            startActivity(Intent(requireContext(), MyReviewListComposeActivity::class.java))
-        }
-
-        binding.tvLogout.setOnClickListener {
-            showLogoutDialog()
-        }
-
-        binding.llSignout.setOnClickListener {
-            // 현재 Success 상태에서 안전하게 닉네임 추출
-            val nickname = (myPageViewModel.uiState.value as? UiState.Success)?.data?.nickname
-            Intent(requireContext(), SignOutActivity::class.java).apply {
-                putExtra("nickname", nickname)
-                startActivity(this)
-            }
-        }
-
-        binding.llDeveloper.setOnClickListener {
-            startActivity(Intent(requireContext(), DeveloperActivity::class.java))
-        }
-
-        binding.llOss.setOnClickListener { moveToOss() }
-
-        binding.llAppVersion.setOnClickListener { moveToPlayStore() }
-
-        binding.llServiceRule.setOnClickListener {
-            startWebView(
-                getString(R.string.terms_url),
-                getString(R.string.terms),
-                ScreenId.EXTERNAL_TERMS
-            )
-        }
-
-        binding.llPrivateInformation.setOnClickListener {
-            startWebView(
-                getString(R.string.policy_url),
-                getString(R.string.policy),
-                ScreenId.EXTERNAL_POLICY
-            )
+    private fun openSignOut() {
+        val nickname = (myPageViewModel.uiState.value as? UiState.Success)?.data?.nickname
+        Intent(requireContext(), SignOutActivity::class.java).apply {
+            putExtra("nickname", nickname)
+            startActivity(this)
         }
     }
 
@@ -220,8 +246,6 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding>(ScreenId.MYPAGE_MAIN)
             ) == PackageManager.PERMISSION_GRANTED
         } else true
     }
-
-    private var lastNotificationPermissionState: Boolean? = null
 
     private fun checkNotificationPermissionChange() {
         val currentPermissionState = checkNotificationPermission(requireContext())

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageScreen.kt
@@ -1,0 +1,338 @@
+package com.eatssu.android.presentation.mypage
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.eatssu.android.R
+import com.eatssu.design_system.theme.EatssuTheme
+import com.eatssu.design_system.theme.Gray300
+import com.eatssu.design_system.theme.Gray400
+import com.eatssu.design_system.theme.Gray500
+import com.eatssu.design_system.theme.Gray700
+import com.eatssu.design_system.theme.White
+
+@Composable
+fun MyPageScreen(
+    state: MyPageState,
+    departmentName: String,
+    onAlarmToggle: (Boolean) -> Unit,
+    onMyInfoClick: () -> Unit,
+    onMyReviewClick: () -> Unit,
+    onInquireClick: () -> Unit,
+    onInstagramClick: () -> Unit,
+    onLanguageSettingClick: () -> Unit,
+    onDeveloperClick: () -> Unit,
+    onOssClick: () -> Unit,
+    onTermRulesClick: () -> Unit,
+    onLogoutClick: () -> Unit,
+    onAppVersionClick: () -> Unit,
+    onSignOutClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(White)
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = dimensionResource(id = R.dimen.bottom_nav_height)),
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.mypage),
+            style = EatssuTheme.typography.subtitle1,
+            color = Gray700,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+        ) {
+            Image(
+                modifier = Modifier
+                    .size(48.dp),
+                painter = painterResource(R.drawable.ic_profile),
+                contentDescription = stringResource(R.string.mypage),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Box(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp),
+            ) {
+                Column {
+                    Text(
+                        text = state.nickname ?: stringResource(R.string.set_nickname),
+                        style = EatssuTheme.typography.subtitle2,
+                        color = Gray700,
+                    )
+
+                    Text(
+                        text = departmentName,
+                        style = EatssuTheme.typography.body3,
+                        color = Gray700,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        MyPageSectionText(
+            text = stringResource(R.string.mypage_push_activity_section_title)
+        )
+
+        NotificationSettingRow(
+            checked = state.isAlarmOn,
+            onCheckedChange = onAlarmToggle,
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.my_info),
+            onClick = onMyInfoClick,
+        )
+        MyPageMenuItem(
+            title = stringResource(R.string.my_review),
+            onClick = onMyReviewClick,
+        )
+
+        MyPageDivider()
+
+        MyPageSectionText(
+            text = stringResource(R.string.mypage_service_section_title)
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.inquire),
+            onClick = onInquireClick,
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.developer),
+            onClick = onDeveloperClick,
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.eatssu_instagram_link),
+            onClick = onInstagramClick,
+        )
+
+        MyPageDivider()
+
+        MyPageSectionText(
+            text = stringResource(R.string.mypage_etc_section_title)
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.language_setting),
+            onClick = onLanguageSettingClick,
+        )
+
+        MyPageMenuItem(
+            title = stringResource(R.string.terms_and_rule),
+            onClick = onTermRulesClick,
+        )
+
+//        MyPageMenuItem(
+//            title = stringResource(R.string.oss_licenses),
+//            onClick = onOssClick,
+//        )
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onLogoutClick)
+                .padding(horizontal = 24.dp, vertical = 18.dp),
+            text = stringResource(R.string.logout),
+            style = EatssuTheme.typography.body1,
+            color = Gray700,
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onAppVersionClick)
+                .padding(horizontal = 24.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.app_version),
+                style = EatssuTheme.typography.caption2,
+                color = Gray400,
+            )
+            Text(
+                text = state.appVersion,
+                style = EatssuTheme.typography.caption2,
+                color = Gray400,
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.End)
+                .clickable(onClick = onSignOutClick)
+                .padding(start = 24.dp, top = 10.dp, end = 24.dp, bottom = 40.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.signout),
+                style = EatssuTheme.typography.caption2,
+                color = Gray400,
+                textDecoration = TextDecoration.Underline,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Image(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(R.drawable.ic_unsubscribe_16),
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+@Composable
+fun MyPageDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(Gray300),
+    )
+}
+
+@Composable
+private fun NotificationSettingRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(top = 10.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(
+                    text = stringResource(R.string.mypage_push_notification_title),
+                    style = EatssuTheme.typography.body1,
+                    color = Gray700,
+                )
+                Text(
+                    text = stringResource(R.string.mypage_push_notification_description),
+                    style = EatssuTheme.typography.caption2,
+                    color = Gray400,
+                )
+            }
+
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+        }
+    }
+}
+
+@Composable
+fun MyPageSectionText(text: String) {
+    Text(
+        modifier = Modifier
+            .padding(start = 24.dp, top = 10.dp),
+        text = text,
+        style = EatssuTheme.typography.caption1,
+        color = Gray500
+    )
+}
+
+@Composable
+fun MyPageMenuItem(
+    title: String,
+    onClick: () -> Unit,
+) {
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = EatssuTheme.typography.body1,
+                color = Gray700,
+            )
+            Icon(
+                modifier = Modifier.size(18.dp),
+                painter = painterResource(R.drawable.ic_arrow_right),
+                contentDescription = null,
+                tint = Gray300,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyPageScreenPreview() {
+    EatssuTheme {
+        MyPageScreen(
+            state = MyPageState(
+                nickname = "hellosoongsil1234",
+                isAlarmOn = true,
+                appVersion = "1.0.0 (1)",
+            ),
+            departmentName = "컴퓨터학부",
+            onAlarmToggle = {},
+            onMyInfoClick = {},
+            onMyReviewClick = {},
+            onInquireClick = {},
+            onInstagramClick = {},
+            onTermRulesClick = {},
+            onDeveloperClick = {},
+            onOssClick = {},
+            onLogoutClick = {},
+            onAppVersionClick = {},
+            onLanguageSettingClick = {},
+            onSignOutClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/terms/TermSelectorActivity.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/terms/TermSelectorActivity.kt
@@ -1,0 +1,46 @@
+package com.eatssu.android.presentation.mypage.terms
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.eatssu.android.R
+import com.eatssu.common.enums.ScreenId
+import com.eatssu.design_system.theme.EatssuTheme
+
+class TermSelectorActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            EatssuTheme {
+                TermSelectorScreen(
+                    onBack = { finish() },
+                    onServiceRuleClick = {
+                        startWebView(
+                            getString(R.string.terms_url),
+                            getString(R.string.terms),
+                            ScreenId.EXTERNAL_TERMS
+                        )
+                    },
+                    onPrivateInformationClick = {
+                        startWebView(
+                            getString(R.string.policy_url),
+                            getString(R.string.policy),
+                            ScreenId.EXTERNAL_POLICY
+                        )
+                    },
+                )
+            }
+
+        }
+    }
+
+    private fun startWebView(url: String, title: String, screenId: ScreenId) {
+        val intent = Intent(applicationContext, WebViewActivity::class.java).apply {
+            putExtra(WebViewActivity.EXTRA_URL, url)
+            putExtra(WebViewActivity.EXTRA_TITLE, title)
+            putExtra("SCREEN_ID", screenId.name)
+        }
+        startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/eatssu/android/presentation/mypage/terms/TermSelectorScreen.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/terms/TermSelectorScreen.kt
@@ -1,0 +1,59 @@
+package com.eatssu.android.presentation.mypage.terms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.eatssu.android.R
+import com.eatssu.android.presentation.mypage.MyPageMenuItem
+import com.eatssu.design_system.component.EatSsuTopBar
+import com.eatssu.design_system.theme.EatssuTheme
+
+@Composable
+fun TermSelectorScreen(
+    modifier: Modifier = Modifier,
+    onServiceRuleClick: () -> Unit = {},
+    onPrivateInformationClick: () -> Unit = {},
+    onBack: () -> Unit = {}
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            EatSsuTopBar(
+                title = stringResource(R.string.terms_and_rule),
+                onBack = onBack
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .padding(horizontal = 24.dp)
+        ) {
+            MyPageMenuItem(
+                title = stringResource(R.string.service_rule),
+                onClick = onServiceRuleClick,
+            )
+
+            MyPageMenuItem(
+                title = stringResource(R.string.private_information),
+                onClick = onPrivateInformationClick,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewTermSelectorScreen(
+) {
+    EatssuTheme {
+        TermSelectorScreen()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,9 @@
     <string name="logout">로그아웃</string>
     <string name="signout">회원탈퇴</string>
     <string name="app_version">앱 버전</string>
+    <string name="mypage_push_activity_section_title">알림 및 활동</string>
+    <string name="mypage_service_section_title">서비스 정보</string>
+    <string name="mypage_etc_section_title">기타</string>
     <string name="mypage_push_notification_title">푸시 알림 설정</string>
     <string name="mypage_push_notification_description">매일 오전 11시에 알림을 보내드려요</string>
 
@@ -257,6 +260,7 @@
     <string name="private_information">개인정보 처리방침</string>
     <string name="policy">개인정보 처리방침</string>
     <string name="terms">서비스 이용약관</string>
+    <string name="terms_and_rule">약관 및 정책</string>
     <string name="developer">만든 사람들</string>
     <string name="oss_licenses">오픈소스 라이브러리</string>
 
@@ -301,6 +305,7 @@
     <string name="policy_url" translatable="false">https://github.com/EAT-SSU/Docs/wiki/EAT%E2%80%90SSU-%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8</string>
     <string name="terms_url" translatable="false">https://github.com/EAT-SSU/Docs/wiki/EAT%E2%80%90SSU-%EC%84%9C%EB%B9%84%EC%8A%A4-%EC%9D%B4%EC%9A%A9%EC%95%BD%EA%B4%80</string>
     <string name="anyone_but_me_url" translatable="false">https://eatssu-coffee.figma.site/</string>
+    <string name="eatssu_instagram_link" translatable="false">EAT-SSU 인스타그램 바로가기</string>
     <string name="eatssu_instagram" translatable="false">eatssu.official</string>
     <string name="eatssu_instagram_url" translatable="false">https://www.instagram.com/eatssu.official/</string>
     <string name="eatssu_event_instagram_url" translatable="false">https://www.instagram.com/p/DVu1n6SEs5b/</string>


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
[마이페이지 리뉴얼](https://www.figma.com/design/oE2DX35Jsl2LoYGIwBtbaC/잇슈2023?node-id=19144-6014&p=f&t=aSCszKeM9VvC6QxI-0)을 진행하면서 기존 MyPageFragment를 Composable UI(MyPageScreen)로 전환했습니다.

[약관 및 정책] 스크린도 추가하면서 일단 지금 뷰 시스템 구조에 맞게 Activity로 한번 더 감쌌습니다

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img width="40%" alt="Android Studio 2026 05 09 163224@2x" src="https://github.com/user-attachments/assets/1aa88b99-6340-45d8-aa3c-18c46dc6d9d0" />
<img width="40%" alt="Android Studio 2026 05 09 163227@2x" src="https://github.com/user-attachments/assets/13f39f72-a9d6-4c3d-a057-cdd076a969c9" />

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->
언어선택 Screen이 만들어진지 얼마 안됐는데 이거 지금 피그마에 맞춰서 수정해야하나요?
