### PR TITLE
2026 봄 축제 탭 추가 및 데이터 반영

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/PartnershipResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/PartnershipResponse.kt
@@ -40,7 +40,7 @@ data class PartnershipResponse(
         @SerialName("endDate")
         val endDate: String? = null,
         @SerialName("periodType")
-        val periodType: String? = null
+        val periodType: PeriodType = PeriodType.NORMAL
     )
 }
 
@@ -61,10 +61,7 @@ fun PartnershipResponse.toDomain(): Partnership =
                 description = it.description ?: "",
                 startDate = it.startDate ?: "",
                 endDate = it.endDate ?: "",
-                periodType = when (it.periodType) {
-                    "FESTIVAL" -> PeriodType.FESTIVAL
-                    else -> PeriodType.NORMAL
-                }
+                periodType = it.periodType
             )
         }
     )

--- a/app/src/main/java/com/eatssu/android/data/remote/dto/response/PartnershipResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/remote/dto/response/PartnershipResponse.kt
@@ -1,6 +1,7 @@
 package com.eatssu.android.data.remote.dto.response
 
 import com.eatssu.android.domain.model.Partnership
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -37,7 +38,9 @@ data class PartnershipResponse(
         @SerialName("startDate")
         val startDate: String? = null,
         @SerialName("endDate")
-        val endDate: String? = null
+        val endDate: String? = null,
+        @SerialName("periodType")
+        val periodType: String? = null
     )
 }
 
@@ -57,7 +60,11 @@ fun PartnershipResponse.toDomain(): Partnership =
                 isLiked = it.isLiked ?: false,
                 description = it.description ?: "",
                 startDate = it.startDate ?: "",
-                endDate = it.endDate ?: ""
+                endDate = it.endDate ?: "",
+                periodType = when (it.periodType) {
+                    "FESTIVAL" -> PeriodType.FESTIVAL
+                    else -> PeriodType.NORMAL
+                }
             )
         }
     )

--- a/app/src/main/java/com/eatssu/android/domain/model/Partnership.kt
+++ b/app/src/main/java/com/eatssu/android/domain/model/Partnership.kt
@@ -1,5 +1,6 @@
 package com.eatssu.android.domain.model
 
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 
 data class Partnership(
@@ -18,6 +19,7 @@ data class Partnership(
         val isLiked: Boolean,
         val description: String,
         val startDate: String,
-        val endDate: String
+        val endDate: String,
+        val periodType: PeriodType,
     )
 }

--- a/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
@@ -77,26 +77,28 @@ class MapViewModel @Inject constructor(
             val userCollegeDepartment = getUserCollegeDepartmentUseCase()
             val newDepartmentId = userCollegeDepartment.userDepartment.departmentId.toLong()
             val newCollegeId = userCollegeDepartment.userCollege.collegeId.toLong()
+            // Festival 존재 여부를 판단하고, All/Festival 초기 목록에도 재사용한다.
+            val allPartnerships = partnershipRepository.getAllPartnerships()
 
             _departmentId.value = newDepartmentId
             _collegeId.value = newCollegeId
 
-            // departmentId가 변경되면 필터 자동 설정
-            val current = uiState.value
-            val currentData = if (current is UiState.Success) current.data else MapState()
-//            val initialFilter = if (newDepartmentId == -1L) FilterType.All else FilterType.Mine // TODO 축제기간 종료 시 주석 해제
-            val initialFilter = FilterType.Festival // TODO 축제기간 한정 Festival 강제. 축제기간 끝나면 주석
+            // Festival 제휴가 하나라도 있으면 Festival을 우선하고, 없으면 기존 기본 필터 규칙을 따른다.
+            val initialFilter = when {
+                allPartnerships.hasFestivalPartnership() -> FilterType.Festival
+                newDepartmentId == -1L -> FilterType.All
+                else -> FilterType.Mine
+            }
             _uiState.value = UiState.Success(
-                MapState(selectedFilter = initialFilter)
+                MapState(selectedFilter = initialFilter),
             )
 
-            // 초기 필터에 따라 데이터 로드
             when (initialFilter) {
-                FilterType.All -> loadPartnerships()
-                FilterType.Festival -> loadFestivalPartnerships()
+                FilterType.All -> loadPartnerships(prefetchedPartnerships = allPartnerships)
+                FilterType.Festival -> loadFestivalPartnerships(prefetchedPartnerships = allPartnerships)
                 FilterType.Mine -> loadUserCollegePartnerships()
             }
-            
+
             Timber.d("학과 정보 : ${userCollegeDepartment.userDepartment.departmentName}")
         }
     }
@@ -149,30 +151,35 @@ class MapViewModel @Inject constructor(
     }
 
     // 제휴 정보 로딩
-    private fun loadPartnerships() {
+    private fun loadPartnerships(
+        prefetchedPartnerships: List<Partnership>? = null,
+    ) {
         viewModelScope.launch {
             val current = uiState.value
             val currentData = if (current is UiState.Success) current.data else MapState()
-            
-            _uiState.value = UiState.Loading
 
-            val partnerships = partnershipRepository.getAllPartnerships()
+            if (prefetchedPartnerships == null)
+                _uiState.value = UiState.Loading
+
+            val partnerships = prefetchedPartnerships ?: partnershipRepository.getAllPartnerships()
             _uiState.value = UiState.Success(
                 currentData.copy(
                     partnerships = partnerships,
-                    filterChangeResult = null
-                )
+                    filterChangeResult = null,
+                ),
             )
         }
     }
 
-    // 축제 정보 로딩
-    private fun loadFestivalPartnerships() {
+    private fun loadFestivalPartnerships(
+        prefetchedPartnerships: List<Partnership>? = null,
+    ) {
         viewModelScope.launch {
             val current = uiState.value
             val currentData = if (current is UiState.Success) current.data else MapState()
 
-            _uiState.value = UiState.Loading
+            if (prefetchedPartnerships == null)
+                _uiState.value = UiState.Loading
 
             val partnerships = partnershipRepository.getAllPartnerships().mapNotNull {
                 val festivalInfos =
@@ -187,8 +194,8 @@ class MapViewModel @Inject constructor(
             _uiState.value = UiState.Success(
                 currentData.copy(
                     partnerships = partnerships,
-                    filterChangeResult = null
-                )
+                    filterChangeResult = null,
+                ),
             )
         }
     }
@@ -205,8 +212,8 @@ class MapViewModel @Inject constructor(
             _uiState.value = UiState.Success(
                 currentData.copy(
                     partnerships = partnerships,
-                    filterChangeResult = null
-                )
+                    filterChangeResult = null,
+                ),
             )
         }
     }
@@ -238,8 +245,22 @@ class MapViewModel @Inject constructor(
             data.copy(
                 restaurantPartnershipInfo = representative,
                 restaurantInfoList = restaurantInfoList,
-                storeType = representative.storeType
-            )
+                storeType = representative.storeType,
+            ),
         )
     }
 }
+
+private fun List<Partnership>.hasFestivalPartnership(): Boolean =
+    any { partnership ->
+        partnership.partnershipInfos.any { info -> info.periodType == PeriodType.FESTIVAL }
+    }
+
+private fun List<Partnership>.festivalPartnerships(): List<Partnership> =
+    mapNotNull { partnership ->
+        val festivalInfos =
+            partnership.partnershipInfos.filter { info -> info.periodType == PeriodType.FESTIVAL }
+        if (festivalInfos.isEmpty()) return@mapNotNull null
+
+        partnership.copy(partnershipInfos = festivalInfos)
+    }

--- a/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
@@ -14,6 +14,7 @@ import com.eatssu.common.UiEvent
 import com.eatssu.common.UiState
 import com.eatssu.common.analytics.AnalyticsTracker
 import com.eatssu.common.analytics.MapAnalyticsEvent
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -83,8 +84,8 @@ class MapViewModel @Inject constructor(
             // departmentId가 변경되면 필터 자동 설정
             val current = uiState.value
             val currentData = if (current is UiState.Success) current.data else MapState()
-            val initialFilter = if (newDepartmentId == -1L) FilterType.All else FilterType.Mine
-
+//            val initialFilter = if (newDepartmentId == -1L) FilterType.All else FilterType.Mine // TODO 축제기간 종료 시 주석 해제
+            val initialFilter = FilterType.Festival // TODO 축제기간 한정 Festival 강제. 축제기간 끝나면 주석
             _uiState.value = UiState.Success(
                 MapState(selectedFilter = initialFilter)
             )
@@ -92,6 +93,7 @@ class MapViewModel @Inject constructor(
             // 초기 필터에 따라 데이터 로드
             when (initialFilter) {
                 FilterType.All -> loadPartnerships()
+                FilterType.Festival -> loadFestivalPartnerships()
                 FilterType.Mine -> loadUserCollegePartnerships()
             }
             
@@ -130,6 +132,10 @@ class MapViewModel @Inject constructor(
                 analyticsTracker.track(MapAnalyticsEvent.AllClicked)
             }
 
+            FilterType.Festival -> {
+                loadFestivalPartnerships()
+            }
+
             FilterType.Mine -> {
                 loadUserCollegePartnerships()
                 analyticsTracker.track(
@@ -151,6 +157,33 @@ class MapViewModel @Inject constructor(
             _uiState.value = UiState.Loading
 
             val partnerships = partnershipRepository.getAllPartnerships()
+            _uiState.value = UiState.Success(
+                currentData.copy(
+                    partnerships = partnerships,
+                    filterChangeResult = null
+                )
+            )
+        }
+    }
+
+    // 축제 정보 로딩
+    private fun loadFestivalPartnerships() {
+        viewModelScope.launch {
+            val current = uiState.value
+            val currentData = if (current is UiState.Success) current.data else MapState()
+
+            _uiState.value = UiState.Loading
+
+            val partnerships = partnershipRepository.getAllPartnerships().mapNotNull {
+                val festivalInfos =
+                    it.partnershipInfos.filter { info -> info.periodType == PeriodType.FESTIVAL }
+                if (festivalInfos.isEmpty()) return@mapNotNull null
+
+                it.copy(
+                    partnershipInfos = festivalInfos
+                )
+            }
+
             _uiState.value = UiState.Success(
                 currentData.copy(
                     partnerships = partnerships,

--- a/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
@@ -27,8 +27,9 @@ import com.eatssu.design_system.theme.White
 import timber.log.Timber
 
 enum class FilterType(@StringRes val labelResId: Int) {
+    Festival(R.string.partnership_filter_festival),
+    All(R.string.partnership_filter_all),
     Mine(R.string.partnership_filter_mine),
-    All(R.string.partnership_filter_all)
 }
 
 @Composable
@@ -42,6 +43,7 @@ fun FilterType.getLabel(departmentName: String): String {
                 departmentName
             }
         }
+        FilterType.Festival -> stringResource(labelResId)
         FilterType.All -> stringResource(labelResId)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,7 @@
     <string name="time">영업 시간</string>
     <string name="favorite_partnership">찜한 제휴</string>
     <string name="partnership_filter_mine">내 제휴</string>
+    <string name="partnership_filter_festival">축제</string>
     <string name="partnership_filter_all">전체</string>
     <string name="partnership_filter_department_placeholder">학과</string>
 

--- a/app/src/test/java/com/eatssu/android/domain/usecase/user/GetPartnershipDetailUseCaseBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/domain/usecase/user/GetPartnershipDetailUseCaseBehaviorSpec.kt
@@ -2,6 +2,7 @@ package com.eatssu.android.domain.usecase.user
 
 import com.eatssu.android.domain.model.Partnership
 import com.eatssu.android.test.AppBehaviorSpec
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 import io.kotest.matchers.shouldBe
 
@@ -20,6 +21,7 @@ class GetPartnershipDetailUseCaseBehaviorSpec : AppBehaviorSpec({
                 description = "10% 할인",
                 startDate = "2025-01-01",
                 endDate = "2025-12-31",
+                periodType = PeriodType.NORMAL
             ),
             Partnership.PartnershipInfo(
                 id = 2,
@@ -31,6 +33,7 @@ class GetPartnershipDetailUseCaseBehaviorSpec : AppBehaviorSpec({
                 description = "음료 증정",
                 startDate = "2025-02-01",
                 endDate = "2025-11-30",
+                periodType = PeriodType.NORMAL
             ),
         )
         val partnerships = listOf(

--- a/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
@@ -11,20 +11,18 @@ import com.eatssu.android.test.AppBehaviorSpec
 import com.eatssu.android.test.samplePartnership
 import com.eatssu.android.test.samplePartnershipRestaurant
 import com.eatssu.android.test.sampleUserInfo
+import com.eatssu.common.UiState
 import com.eatssu.common.analytics.AnalyticsTracker
 import com.eatssu.common.analytics.MapAnalyticsEvent
-import com.eatssu.common.UiState
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.matchers.shouldBe
-import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -67,6 +65,72 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                         state.data.partnerships shouldBe allPartnerships
                     }
                     coVerify(atLeast = 1) { partnershipRepository.getAllPartnerships() }
+                }
+            }
+        }
+
+        `when`("전체 제휴에 Festival 요소가 하나라도 있으면") {
+            val festivalInfo = Partnership.PartnershipInfo(
+                id = 2,
+                partnershipType = "EVENT",
+                collegeName = "IT",
+                departmentName = "컴퓨터학부",
+                likeCount = 5,
+                isLiked = false,
+                description = "축제 할인",
+                startDate = "2025-05-01",
+                endDate = "2025-05-31",
+                periodType = PeriodType.FESTIVAL,
+            )
+            val normalInfo = Partnership.PartnershipInfo(
+                id = 1,
+                partnershipType = "DISCOUNT",
+                collegeName = "IT",
+                departmentName = "컴퓨터학부",
+                likeCount = 2,
+                isLiked = true,
+                description = "상시 할인",
+                startDate = "2025-01-01",
+                endDate = "2025-12-31",
+                periodType = PeriodType.NORMAL,
+            )
+            val allPartnerships = listOf(
+                samplePartnership(
+                    storeName = "Festival Cafe",
+                    infos = listOf(normalInfo, festivalInfo),
+                ),
+                samplePartnership(storeName = "Normal Cafe"),
+            )
+            coEvery {
+                getUserCollegeDepartmentUseCase()
+            } returns sampleUserInfo(
+                nickname = "eatssu",
+                college = College(collegeId = 1, collegeName = "IT"),
+                department = Department(departmentId = 11, departmentName = "컴퓨터학부"),
+            )
+            coEvery { partnershipRepository.getAllPartnerships() } returns allPartnerships
+            coEvery { partnershipRepository.getUserCollegePartnerships() } returns listOf(
+                samplePartnership(storeName = "Mine Cafe"),
+            )
+
+            val viewModel = MapViewModel(
+                partnershipRepository = partnershipRepository,
+                getPartnershipDetailUseCase = getPartnershipDetailUseCase,
+                getUserCollegeDepartmentUseCase = getUserCollegeDepartmentUseCase,
+                analyticsTracker = analyticsTracker,
+            )
+
+            then("Festival 필터로 시작하고 Festival 정보만 노출한다") {
+                runTest {
+                    eventually(2.seconds) {
+                        val state = viewModel.uiState.value as UiState.Success
+                        state.data.selectedFilter shouldBe FilterType.Festival
+                        state.data.partnerships shouldBe listOf(
+                            allPartnerships.first().copy(partnershipInfos = listOf(festivalInfo)),
+                        )
+                    }
+                    coVerify(exactly = 1) { partnershipRepository.getAllPartnerships() }
+                    coVerify(exactly = 0) { partnershipRepository.getUserCollegePartnerships() }
                 }
             }
         }
@@ -158,6 +222,46 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
             }
         }
 
+        `when`("필터 변경 후 목록 로딩이 지연되면") {
+            val minePartnerships = listOf(samplePartnership(storeName = "Mine Cafe"))
+            val allPartnerships = listOf(samplePartnership(storeName = "All Cafe"))
+            coEvery {
+                getUserCollegeDepartmentUseCase()
+            } returns sampleUserInfo(
+                nickname = "eatssu",
+                college = College(collegeId = 1, collegeName = "IT"),
+                department = Department(departmentId = 11, departmentName = "컴퓨터학부"),
+            )
+            coEvery { partnershipRepository.getUserCollegePartnerships() } returns minePartnerships
+            coEvery { partnershipRepository.getAllPartnerships() } returns emptyList()
+
+            val viewModel = MapViewModel(
+                partnershipRepository = partnershipRepository,
+                getPartnershipDetailUseCase = getPartnershipDetailUseCase,
+                getUserCollegeDepartmentUseCase = getUserCollegeDepartmentUseCase,
+                analyticsTracker = analyticsTracker,
+            )
+
+            then("선택된 탭 상태를 Loading으로 잃지 않는다") {
+                runTest {
+                    eventually(2.seconds) {
+                        val initial = viewModel.uiState.value as UiState.Success
+                        initial.data.selectedFilter shouldBe FilterType.Mine
+                        initial.data.partnerships shouldBe minePartnerships
+                    }
+
+                    coEvery { partnershipRepository.getAllPartnerships() } coAnswers {
+                        delay(10_000)
+                        allPartnerships
+                    }
+                    viewModel.setFilter(FilterType.All)
+
+                    val state = viewModel.uiState.value as UiState.Success
+                    state.data.selectedFilter shouldBe FilterType.All
+                }
+            }
+        }
+
         `when`("가게를 선택하면") {
             val partnershipInfos = listOf(
                 Partnership.PartnershipInfo(
@@ -170,6 +274,7 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                     description = "10% 할인",
                     startDate = "2025-01-01",
                     endDate = "2025-12-31",
+                    periodType = PeriodType.NORMAL,
                 ),
                 Partnership.PartnershipInfo(
                     id = 2,
@@ -181,6 +286,7 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                     description = "음료 증정",
                     startDate = "2025-02-01",
                     endDate = "2025-11-30",
+                    periodType = PeriodType.NORMAL,
                 ),
             )
             val partnerships = listOf(
@@ -310,6 +416,7 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                             description = "할인",
                             startDate = "2025-01-01",
                             endDate = "2025-12-31",
+                            periodType = PeriodType.NORMAL,
                         )
                     ),
                 )

--- a/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
@@ -69,72 +69,6 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
             }
         }
 
-        `when`("전체 제휴에 Festival 요소가 하나라도 있으면") {
-            val festivalInfo = Partnership.PartnershipInfo(
-                id = 2,
-                partnershipType = "EVENT",
-                collegeName = "IT",
-                departmentName = "컴퓨터학부",
-                likeCount = 5,
-                isLiked = false,
-                description = "축제 할인",
-                startDate = "2025-05-01",
-                endDate = "2025-05-31",
-                periodType = PeriodType.FESTIVAL,
-            )
-            val normalInfo = Partnership.PartnershipInfo(
-                id = 1,
-                partnershipType = "DISCOUNT",
-                collegeName = "IT",
-                departmentName = "컴퓨터학부",
-                likeCount = 2,
-                isLiked = true,
-                description = "상시 할인",
-                startDate = "2025-01-01",
-                endDate = "2025-12-31",
-                periodType = PeriodType.NORMAL,
-            )
-            val allPartnerships = listOf(
-                samplePartnership(
-                    storeName = "Festival Cafe",
-                    infos = listOf(normalInfo, festivalInfo),
-                ),
-                samplePartnership(storeName = "Normal Cafe"),
-            )
-            coEvery {
-                getUserCollegeDepartmentUseCase()
-            } returns sampleUserInfo(
-                nickname = "eatssu",
-                college = College(collegeId = 1, collegeName = "IT"),
-                department = Department(departmentId = 11, departmentName = "컴퓨터학부"),
-            )
-            coEvery { partnershipRepository.getAllPartnerships() } returns allPartnerships
-            coEvery { partnershipRepository.getUserCollegePartnerships() } returns listOf(
-                samplePartnership(storeName = "Mine Cafe"),
-            )
-
-            val viewModel = MapViewModel(
-                partnershipRepository = partnershipRepository,
-                getPartnershipDetailUseCase = getPartnershipDetailUseCase,
-                getUserCollegeDepartmentUseCase = getUserCollegeDepartmentUseCase,
-                analyticsTracker = analyticsTracker,
-            )
-
-            then("Festival 필터로 시작하고 Festival 정보만 노출한다") {
-                runTest {
-                    eventually(2.seconds) {
-                        val state = viewModel.uiState.value as UiState.Success
-                        state.data.selectedFilter shouldBe FilterType.Festival
-                        state.data.partnerships shouldBe listOf(
-                            allPartnerships.first().copy(partnershipInfos = listOf(festivalInfo)),
-                        )
-                    }
-                    coVerify(exactly = 1) { partnershipRepository.getAllPartnerships() }
-                    coVerify(exactly = 0) { partnershipRepository.getUserCollegePartnerships() }
-                }
-            }
-        }
-
         `when`("학과 정보가 없는 사용자가 Mine 필터를 선택하면") {
             coEvery {
                 getUserCollegeDepartmentUseCase()
@@ -218,46 +152,6 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                             MapAnalyticsEvent.MineClicked(college = 1L, major = 11L),
                         )
                     }
-                }
-            }
-        }
-
-        `when`("필터 변경 후 목록 로딩이 지연되면") {
-            val minePartnerships = listOf(samplePartnership(storeName = "Mine Cafe"))
-            val allPartnerships = listOf(samplePartnership(storeName = "All Cafe"))
-            coEvery {
-                getUserCollegeDepartmentUseCase()
-            } returns sampleUserInfo(
-                nickname = "eatssu",
-                college = College(collegeId = 1, collegeName = "IT"),
-                department = Department(departmentId = 11, departmentName = "컴퓨터학부"),
-            )
-            coEvery { partnershipRepository.getUserCollegePartnerships() } returns minePartnerships
-            coEvery { partnershipRepository.getAllPartnerships() } returns emptyList()
-
-            val viewModel = MapViewModel(
-                partnershipRepository = partnershipRepository,
-                getPartnershipDetailUseCase = getPartnershipDetailUseCase,
-                getUserCollegeDepartmentUseCase = getUserCollegeDepartmentUseCase,
-                analyticsTracker = analyticsTracker,
-            )
-
-            then("선택된 탭 상태를 Loading으로 잃지 않는다") {
-                runTest {
-                    eventually(2.seconds) {
-                        val initial = viewModel.uiState.value as UiState.Success
-                        initial.data.selectedFilter shouldBe FilterType.Mine
-                        initial.data.partnerships shouldBe minePartnerships
-                    }
-
-                    coEvery { partnershipRepository.getAllPartnerships() } coAnswers {
-                        delay(10_000)
-                        allPartnerships
-                    }
-                    viewModel.setFilter(FilterType.All)
-
-                    val state = viewModel.uiState.value as UiState.Success
-                    state.data.selectedFilter shouldBe FilterType.All
                 }
             }
         }

--- a/app/src/test/java/com/eatssu/android/test/TestFixtures.kt
+++ b/app/src/test/java/com/eatssu/android/test/TestFixtures.kt
@@ -8,6 +8,7 @@ import com.eatssu.android.domain.model.Review
 import com.eatssu.android.domain.model.ReviewInfo
 import com.eatssu.android.domain.model.Token
 import com.eatssu.android.domain.model.UserInfo
+import com.eatssu.common.enums.PeriodType
 import com.eatssu.common.enums.StoreType
 
 fun sampleCollege(
@@ -83,6 +84,7 @@ fun samplePartnership(
             description = "desc",
             startDate = "2025-01-01",
             endDate = "2025-12-31",
+            periodType = PeriodType.NORMAL,
         ),
     ),
     type: StoreType = StoreType.CAFE,

--- a/core/common/src/main/java/com/eatssu/common/enums/PeriodType.kt
+++ b/core/common/src/main/java/com/eatssu/common/enums/PeriodType.kt
@@ -1,5 +1,8 @@
 package com.eatssu.common.enums
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 enum class PeriodType {
     FESTIVAL, NORMAL
 }

--- a/core/common/src/main/java/com/eatssu/common/enums/PeriodType.kt
+++ b/core/common/src/main/java/com/eatssu/common/enums/PeriodType.kt
@@ -1,0 +1,5 @@
+package com.eatssu.common.enums
+
+enum class PeriodType {
+    FESTIVAL, NORMAL
+}


### PR DESCRIPTION
## Summary
기존 PartnerShipInfo에 periodType을 추가하고 지도에 [축제] 탭을 추가해서 PeriodType.FESTIVAL 인 데이터만 모아볼 수 있도록 했습니다 


## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
https://github.com/user-attachments/assets/9504854f-9e77-41ff-88b0-d0fbf7a890be

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

