### PR TITLE
[Fix] 지도에 상도시장이 즉시 보이도록 줌 축소

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
@@ -92,7 +92,7 @@ import timber.log.Timber
 
 private const val DEFAULT_LATITUDE = 37.49517278813046
 private const val DEFAULT_LONGITUDE = 126.95661313346206
-private const val DEFAULT_ZOOM = 17.5
+private const val DEFAULT_ZOOM = 14.5
 private const val PERMISSION_REQUEST_CODE = 1001
 
 @Composable


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
지도에 상도시장이 즉시 보이도록 DEFAULT_ZOOM를 14.5로 낮췄습니다

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img width="668" height="1516" alt="Android Studio 2026 05 12 125105@2x" src="https://github.com/user-attachments/assets/0f0f9822-161d-45eb-84ae-5d5137be9d83" />

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

