### PR TITLE
release: 3.2.11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 63
-        versionName = "3.2.10"
+        versionCode = 64
+        versionName = "3.2.11"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.11.yml
+++ b/release-notes/v3.2.11.yml
@@ -1,0 +1,8 @@
+ko: |
+  - 마이페이지 화면이 새 디자인으로 더 보기 편해졌어요.
+  - 축제 정보에서 2026 봄 축제 탭을 확인할 수 있어요.
+  - 지도에서 상도시장이 더 바로 보이도록 화면 범위가 조정됐어요.
+en: |
+  - The My Page screen has a refreshed design for easier browsing.
+  - You can now find the 2026 spring festival tab in festival information.
+  - The map view now opens wider so Sangdo Market appears right away.


### PR DESCRIPTION
## Release 3.2.11

### 변경사항 (3.2.10 → 3.2.11)

| 커밋 | 설명 | PR |
|------|------|----|
| `c344622a` | 지도에 상도시장이 즉시 보이도록 줌 축소 | #520 |
| `77dfb929` | 2026 봄 축제 탭 추가 및 데이터 반영 | #519 |
| `7f461350` | 마이페이지 디자인 반영 및 Compose 전환 | #518 |

### 릴리즈 노트 (Play Store)

**한국어**
- 마이페이지 화면이 새 디자인으로 더 보기 편해졌어요.
- 축제 정보에서 2026 봄 축제 탭을 확인할 수 있어요.
- 지도에서 상도시장이 더 바로 보이도록 화면 범위가 조정됐어요.

**English**
- The My Page screen has a refreshed design for easier browsing.
- You can now find the 2026 spring festival tab in festival information.
- The map view now opens wider so Sangdo Market appears right away.

### 버전 정보
- `versionCode`: 63 → 64
- `versionName`: 3.2.10 → 3.2.11