### PR TITLE
지도 축제탭 별도 색상 지정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.eatssu.android.R
 import com.eatssu.design_system.theme.EatssuTheme
+import com.eatssu.design_system.theme.Festival
 import com.eatssu.design_system.theme.Gray300
 import com.eatssu.design_system.theme.Gray600
 import com.eatssu.design_system.theme.Primary
@@ -84,7 +85,13 @@ fun PartnershipToggleItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor = if (selected) Primary else Color.Transparent
+    val backgroundColor =
+        if (selected && (label == stringResource(R.string.partnership_filter_festival)))
+            Festival
+        else if (selected)
+            Primary
+        else
+            Color.Transparent
     val textColor = if (selected) White else Gray600
 
     Box(

--- a/core/design-system/src/main/java/com/eatssu/design_system/theme/Color.kt
+++ b/core/design-system/src/main/java/com/eatssu/design_system/theme/Color.kt
@@ -16,6 +16,7 @@ val Gray700 = Color(0xFF1F1F1F)
 // Brand
 val Primary = Color(0xFF66D4C2)
 val Secondary = Color(0xFFEEFBF8)
+val Festival = Color(0xFF97AFFF)
 
 // Yellow
 val Star = Color(0xFFFFC700)


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
지도 축제 탭에 별도 색상 지정했습니다

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img width="458" height="866" alt="Android Studio 2026 05 12 165209@2x" src="https://github.com/user-attachments/assets/7c664771-222c-4fec-b606-804eecb01b57" />

## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

