### PR TITLE
release: 3.2.12

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 64
-        versionName = "3.2.11"
+        versionCode = 65
+        versionName = "3.2.12"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.12.yml
+++ b/release-notes/v3.2.12.yml
@@ -1,0 +1,4 @@
+ko: |
+  - 지도에서 축제 탭 색상이 더 명확하게 구분되도록 개선했어요.
+en: |
+  - It is now easier to distinguish the festival tab color on the map.


### PR DESCRIPTION
## Release 3.2.12

### 변경사항 (3.2.11 → 3.2.12)

| 커밋 | 설명 | PR |
|------|------|----|
| `f89f0f34` | 지도 축제탭 별도 색상 지정 | #522 |

### 릴리즈 노트 (Play Store)

**한국어**
- 지도에서 축제 탭 색상이 더 명확하게 구분되도록 개선했어요.

**English**
- It is now easier to distinguish the festival tab color on the map.

### 버전 정보
- `versionCode`: 64 → 65
- `versionName`: 3.2.11 → 3.2.12
