### PR TITLE
[feat] 만든 사람들 노션 페이지로 이어지도록 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/mypage/MyPageFragment.kt
@@ -139,11 +139,10 @@ class MyPageFragment : Fragment() {
                                         )
                                     },
                                     onDeveloperClick = {
-                                        startActivity(
-                                            Intent(
-                                                requireContext(),
-                                                DeveloperActivity::class.java
-                                            )
+                                        startWebView(
+                                            getString(R.string.developer_url),
+                                            getString(R.string.developer),
+                                            ScreenId.EXTERNAL_TERMS
                                         )
                                     },
                                     onOssClick = ::moveToOss,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,4 +311,5 @@
     <string name="eatssu_instagram_url" translatable="false">https://www.instagram.com/eatssu.official/</string>
     <string name="eatssu_event_instagram_url" translatable="false">https://www.instagram.com/p/DVu1n6SEs5b/</string>
     <string name="recruiting_url" translatable="false">https://eat-ssu.notion.site/1d2eeef75a1681ae800cf6ffa6faa37d?pvs=74</string>
+    <string name="developer_url" translatable="false">https://eat-ssu.notion.site/1d2eeef75a16814db1e5c5abaf40cf6a?pvs=73</string>
 </resources>


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
[113차 회의](https://www.notion.so/eat-ssu/113-363eeef75a1680b2adf6c7f4431c104b?source=copy_link)에서 한번 더 전달받은 대로 마이페이지의 [만든 사람들] 버튼을 눌렀을 때 앱 내 액티비티가 아닌 웹뷰를 통해 노션페이지로 이동하도록 수정했습니다.
## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img width="30%" height="1450" alt="Android Studio 2026 05 22 145621@2x" src="https://github.com/user-attachments/assets/793178d4-f73b-40c2-a81d-8e23c3469ff6" />


## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

