### PR TITLE
[bugfix] 축제 제휴 데이터가 없는 경우에는 필터에서도 사라지도록 수정

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapFragmentView.kt
@@ -466,7 +466,8 @@ internal fun MapScreen(
                     onSelectedFilterChange(next)
                 },
                 modifier = Modifier.padding(top = 12.dp),
-                departmentName = departmentName.toString()
+                departmentName = departmentName.toString(),
+                filters = mapState.availableFilters,
             )
         }
     }

--- a/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/MapViewModel.kt
@@ -40,6 +40,7 @@ data class MapState(
     val restaurantInfoList: List<RestaurantInfo> = emptyList(),
     val storeType: StoreType? = null,
     val selectedFilter: FilterType = FilterType.Mine,
+    val availableFilters: List<FilterType> = FilterType.entries,
     val filterChangeResult: FilterChangeResult? = null,
 ) {
     sealed class FilterChangeResult {
@@ -83,14 +84,24 @@ class MapViewModel @Inject constructor(
             _departmentId.value = newDepartmentId
             _collegeId.value = newCollegeId
 
+            val hasFestival = allPartnerships.hasFestivalPartnership()
+            val availableFilters = if (hasFestival) {
+                FilterType.entries
+            } else {
+                listOf(FilterType.All, FilterType.Mine)
+            }
+
             // Festival 제휴가 하나라도 있으면 Festival을 우선하고, 없으면 기존 기본 필터 규칙을 따른다.
             val initialFilter = when {
-                allPartnerships.hasFestivalPartnership() -> FilterType.Festival
+                hasFestival -> FilterType.Festival
                 newDepartmentId == -1L -> FilterType.All
                 else -> FilterType.Mine
             }
             _uiState.value = UiState.Success(
-                MapState(selectedFilter = initialFilter),
+                MapState(
+                    selectedFilter = initialFilter,
+                    availableFilters = availableFilters,
+                ),
             )
 
             when (initialFilter) {
@@ -181,15 +192,9 @@ class MapViewModel @Inject constructor(
             if (prefetchedPartnerships == null)
                 _uiState.value = UiState.Loading
 
-            val partnerships = partnershipRepository.getAllPartnerships().mapNotNull {
-                val festivalInfos =
-                    it.partnershipInfos.filter { info -> info.periodType == PeriodType.FESTIVAL }
-                if (festivalInfos.isEmpty()) return@mapNotNull null
-
-                it.copy(
-                    partnershipInfos = festivalInfos
-                )
-            }
+            val partnerships =
+                (prefetchedPartnerships ?: partnershipRepository.getAllPartnerships())
+                    .festivalPartnerships()
 
             _uiState.value = UiState.Success(
                 currentData.copy(

--- a/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/map/component/PartnershipToggleItem.kt
@@ -54,10 +54,11 @@ fun PartnershipFilterToggle(
     selected: FilterType,
     onSelectedChange: (FilterType) -> Unit,
     departmentName: String,
+    filters: List<FilterType> = FilterType.entries,
     modifier: Modifier = Modifier,
 ) {
     Timber.d("departmentName = $departmentName")
-    val items = FilterType.entries.map {
+    val items = filters.map {
         it to it.getLabel(departmentName)
     }
     Row(

--- a/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/map/MapViewModelBehaviorSpec.kt
@@ -62,9 +62,72 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
                     eventually(2.seconds) {
                         val state = viewModel.uiState.value as UiState.Success
                         state.data.selectedFilter shouldBe FilterType.All
+                        state.data.availableFilters shouldBe listOf(FilterType.All, FilterType.Mine)
                         state.data.partnerships shouldBe allPartnerships
                     }
                     coVerify(atLeast = 1) { partnershipRepository.getAllPartnerships() }
+                }
+            }
+        }
+
+        `when`("Festival 제휴가 있으면") {
+            val festivalInfo = Partnership.PartnershipInfo(
+                id = 1,
+                partnershipType = "DISCOUNT",
+                collegeName = "IT",
+                departmentName = "CS",
+                likeCount = 1,
+                isLiked = false,
+                description = "축제 할인",
+                startDate = "2025-05-01",
+                endDate = "2025-05-03",
+                periodType = PeriodType.FESTIVAL,
+            )
+            val normalInfo = Partnership.PartnershipInfo(
+                id = 2,
+                partnershipType = "DISCOUNT",
+                collegeName = "IT",
+                departmentName = "CS",
+                likeCount = 1,
+                isLiked = false,
+                description = "상시 할인",
+                startDate = "2025-01-01",
+                endDate = "2025-12-31",
+                periodType = PeriodType.NORMAL,
+            )
+            val allPartnerships = listOf(
+                samplePartnership(
+                    storeName = "Festival Cafe",
+                    infos = listOf(festivalInfo, normalInfo),
+                )
+            )
+            coEvery {
+                getUserCollegeDepartmentUseCase()
+            } returns sampleUserInfo(
+                nickname = "eatssu",
+                college = College(collegeId = 1, collegeName = "IT"),
+                department = Department(departmentId = 11, departmentName = "컴퓨터학부"),
+            )
+            coEvery { partnershipRepository.getAllPartnerships() } returns allPartnerships
+            coEvery { partnershipRepository.getUserCollegePartnerships() } returns emptyList()
+
+            val viewModel = MapViewModel(
+                partnershipRepository = partnershipRepository,
+                getPartnershipDetailUseCase = getPartnershipDetailUseCase,
+                getUserCollegeDepartmentUseCase = getUserCollegeDepartmentUseCase,
+                analyticsTracker = analyticsTracker,
+            )
+
+            then("Festival 필터로 시작하고 Festival 필터 버튼을 표시한다") {
+                runTest {
+                    eventually(2.seconds) {
+                        val state = viewModel.uiState.value as UiState.Success
+                        state.data.selectedFilter shouldBe FilterType.Festival
+                        state.data.availableFilters shouldBe FilterType.entries.toList()
+                        state.data.partnerships.first().partnershipInfos shouldBe listOf(
+                            festivalInfo
+                        )
+                    }
                 }
             }
         }
@@ -90,7 +153,9 @@ class MapViewModelBehaviorSpec : AppBehaviorSpec({
             then("RequiresDepartment 결과를 상태에 반영하고 Mine 데이터를 로드하지 않는다") {
                 runTest {
                     eventually(2.seconds) {
-                        viewModel.uiState.value shouldBe UiState.Success(MapState(selectedFilter = FilterType.All))
+                        val state = viewModel.uiState.value as UiState.Success
+                        state.data.selectedFilter shouldBe FilterType.All
+                        state.data.availableFilters shouldBe listOf(FilterType.All, FilterType.Mine)
                     }
 
                     clearMocks(partnershipRepository, answers = false, recordedCalls = true)


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
잇슈 iOS 앱을 보니까 현재 필터에 축제 탭이 없더라고요. 안드로이드에서도 축제 제휴 데이터가 없는 경우에 필터에서 사라지게 수정했습니다.
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
<img width="30%" height="868" alt="Android Studio 2026 05 22 151753@2x" src="https://github.com/user-attachments/assets/33c6b5b9-ec01-48ce-a00e-c30e3883bde3" />



## Issue

- Resolves #

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

