### PR TITLE
release: 3.2.13

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.eatssu.android"
         minSdk = 28
         targetSdk = 35
-        versionCode = 65
-        versionName = "3.2.12"
+        versionCode = 66
+        versionName = "3.2.13"
 
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/release-notes/v3.2.13.yml
+++ b/release-notes/v3.2.13.yml
@@ -1,0 +1,10 @@
+ko: |
+  - 앱 안에서 언어를 더 자연스럽게 선택하고 사용할 수 있어요.
+  - 축제 제휴 정보가 없을 때 필터에 불필요한 항목이 보이지 않아요.
+  - 만든 사람들 정보를 노션 페이지에서 바로 확인할 수 있어요.
+  - 앱 이용 경험을 더 정확하게 개선할 수 있도록 안정성을 다듬었어요.
+en: |
+  - You can now choose and use languages more smoothly in the app.
+  - Festival partnership filters no longer show unnecessary items when no partnership information is available.
+  - You can now open the team information directly on the Notion page.
+  - App stability has been refined to help improve the overall experience more accurately.


### PR DESCRIPTION
## Release 3.2.13

### 변경사항 (3.2.12 → 3.2.13)

| 커밋 | 설명 | PR |
|------|------|----|
| `a4587b82` | [feat] change_language 이벤트 설계 (앱 내 언어 설정이 바뀐 경우) | #528 |
| `96b90c9d` | [feat] Posthog 이벤트 수정 및 신규 생성 | #527 |
| `c44e1c45` | [bugfix] 축제 제휴 데이터가 없는 경우에는 필터에서도 사라지도록 수정 | #526 |
| `11c90381` | [feat] 만든 사람들 노션 페이지로 이어지도록 수정 | #525 |
| `b0a951fe` | [feat] 언어선택 UI 반영 및 언어 CSV 변환 Gradle Task 추가 | #524 |

### 릴리즈 노트 (Play Store)

**한국어**
- 앱 안에서 언어를 더 자연스럽게 선택하고 사용할 수 있어요.
- 축제 제휴 정보가 없을 때 필터에 불필요한 항목이 보이지 않아요.
- 만든 사람들 정보를 노션 페이지에서 바로 확인할 수 있어요.
- 앱 이용 경험을 더 정확하게 개선할 수 있도록 안정성을 다듬었어요.

**English**
- You can now choose and use languages more smoothly in the app.
- Festival partnership filters no longer show unnecessary items when no partnership information is available.
- You can now open the team information directly on the Notion page.
- App stability has been refined to help improve the overall experience more accurately.

### 버전 정보
- `versionCode`: 65 → 66
- `versionName`: 3.2.12 → 3.2.13
