### PR TITLE
[Feat] 리뷰 번역 일본어·베트남어 지원 추가

### DIFF
--- a/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/translation/ReviewTranslationLanguage.kt
+++ b/app/src/main/java/com/eatssu/android/presentation/cafeteria/review/translation/ReviewTranslationLanguage.kt
@@ -8,14 +8,14 @@ fun currentReviewTranslationTargetLanguage(): String? =
     reviewTranslationTargetLanguage(LocalConfiguration.current.locales[0].language)
 
 fun reviewTranslationTargetLanguage(appLanguageCode: String): String? =
-    ENGLISH_TARGET_LANGUAGE.takeIf { appLanguageCode == ENGLISH_APP_LANGUAGE_CODE }
+    REVIEW_TRANSLATION_TARGET_LANGUAGES[appLanguageCode]
 
 fun shouldShowReviewTranslationAction(
     targetLanguage: String?,
     isLoggedIn: Boolean,
     content: String,
 ): Boolean = isLoggedIn &&
-    targetLanguage == ENGLISH_TARGET_LANGUAGE &&
+    targetLanguage in SUPPORTED_TARGET_LANGUAGES &&
     content.any { character ->
         character.code in HANGUL_SYLLABLE_RANGE ||
             character.code in HANGUL_JAMO_RANGE ||
@@ -25,5 +25,9 @@ fun shouldShowReviewTranslationAction(
 private val HANGUL_SYLLABLE_RANGE = 0xAC00..0xD7A3
 private val HANGUL_JAMO_RANGE = 0x1100..0x11FF
 private val HANGUL_COMPATIBILITY_JAMO_RANGE = 0x3130..0x318F
-private const val ENGLISH_APP_LANGUAGE_CODE = "en"
-private const val ENGLISH_TARGET_LANGUAGE = "EN"
+private val REVIEW_TRANSLATION_TARGET_LANGUAGES = mapOf(
+    "en" to "EN",
+    "ja" to "JA",
+    "vi" to "VI",
+)
+private val SUPPORTED_TARGET_LANGUAGES = REVIEW_TRANSLATION_TARGET_LANGUAGES.values.toSet()

--- a/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/translation/ReviewTranslationLanguageBehaviorSpec.kt
+++ b/app/src/test/java/com/eatssu/android/presentation/cafeteria/review/translation/ReviewTranslationLanguageBehaviorSpec.kt
@@ -5,27 +5,32 @@ import io.kotest.matchers.shouldBe
 
 class ReviewTranslationLanguageBehaviorSpec : AppBehaviorSpec({
 
-    given("영어 번역 버튼 노출 조건") {
+    given("다국어 번역 버튼 노출 조건") {
         `when`("리뷰에 한글이 포함되어 있으면") {
-            then("번역 버튼을 보여준다") {
-                shouldShowReviewTranslationAction("EN", true, "맛있어요") shouldBe true
-                shouldShowReviewTranslationAction("EN", true, "good ㅋㅋ") shouldBe true
+            then("지원하는 모든 언어에서 번역 버튼을 보여준다") {
+                listOf("EN", "JA", "VI").forEach { targetLanguage ->
+                    shouldShowReviewTranslationAction(targetLanguage, true, "맛있어요") shouldBe true
+                    shouldShowReviewTranslationAction(targetLanguage, true, "good ㅋㅋ") shouldBe true
+                }
             }
         }
 
         `when`("리뷰에 한글이 없으면") {
             then("번역 버튼을 숨긴다") {
-                shouldShowReviewTranslationAction("EN", true, "yoyoyoyoy") shouldBe false
-                shouldShowReviewTranslationAction("EN", true, "Already in English") shouldBe false
-                shouldShowReviewTranslationAction("EN", true, "おいしいです") shouldBe false
-                shouldShowReviewTranslationAction("EN", true, "ngon quá") shouldBe false
-                shouldShowReviewTranslationAction("EN", true, "123 !!!") shouldBe false
+                listOf("EN", "JA", "VI").forEach { targetLanguage ->
+                    shouldShowReviewTranslationAction(targetLanguage, true, "yoyoyoyoy") shouldBe false
+                    shouldShowReviewTranslationAction(targetLanguage, true, "Already in English") shouldBe false
+                    shouldShowReviewTranslationAction(targetLanguage, true, "おいしいです") shouldBe false
+                    shouldShowReviewTranslationAction(targetLanguage, true, "ngon quá") shouldBe false
+                    shouldShowReviewTranslationAction(targetLanguage, true, "123 !!!") shouldBe false
+                }
             }
         }
 
         `when`("지원하지 않는 번역 언어이면") {
             then("번역 버튼을 숨긴다") {
                 shouldShowReviewTranslationAction(null, true, "맛있어요") shouldBe false
+                shouldShowReviewTranslationAction("KO", true, "맛있어요") shouldBe false
             }
         }
 
@@ -36,11 +41,12 @@ class ReviewTranslationLanguageBehaviorSpec : AppBehaviorSpec({
         }
 
         `when`("앱 언어로 번역 대상 언어를 결정하면") {
-            then("영어 앱에서만 영어 번역을 지원한다") {
+            then("영어, 일본어, 베트남어 앱에서 해당 언어로 번역한다") {
                 reviewTranslationTargetLanguage("en") shouldBe "EN"
+                reviewTranslationTargetLanguage("ja") shouldBe "JA"
+                reviewTranslationTargetLanguage("vi") shouldBe "VI"
                 reviewTranslationTargetLanguage("ko") shouldBe null
-                reviewTranslationTargetLanguage("ja") shouldBe null
-                reviewTranslationTargetLanguage("vi") shouldBe null
+                reviewTranslationTargetLanguage("fr") shouldBe null
             }
         }
     }


### PR DESCRIPTION
## Summary

서버의 리뷰 번역 지원 언어 확장 -> Android에서 일본어와 베트남어 리뷰 번역 지원을 추가합니다.

## Describe your changes

- 앱 언어에 따른 번역 대상 언어 매핑 추가
  - 영어: `EN`
  - 일본어: `JA`
  - 베트남어: `VI`
- 일본어·베트남어 환경에서도 로그인 상태의 한글 리뷰에 번역 버튼 노출
- 미지원 언어, 비로그인 상태, 한글이 없는 리뷰에서는 번역 버튼 미노출
- 다국어 번역 버튼 노출 조건 단위 테스트 추가

## Test

- 실기기 테스트 완료
- 일본어 번역 및 원문 보기 동작 확인
- 베트남어 번역 및 원문 보기 동작 확인

## Issue


## To reviewers

- 앱 언어별 요청값이 `EN`, `JA`, `VI`로 올바르게 전달되는지 확인 부탁드립니다.
- 번역 화면과 캐시 등 기존 동작은 변경하지 않고 언어 노출 범위만 확장했습니다.